### PR TITLE
Add ChatGPT link to AI models section

### DIFF
--- a/index.html
+++ b/index.html
@@ -824,6 +824,12 @@
         <section class="mb-20 fade-in">
             <h2 class="category-title">AI Foundation Models</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6">
+                <a href="https://chatgpt.com/" target="_blank" class="tool-card modern-card">
+                    <div class="tool-content">
+                        <h3 class="text-xl font-bold mb-2 text-gray-800">ChatGPT</h3>
+                        <p class="text-gray-600">OpenAI Conversational AI</p>
+                    </div>
+                </a>
                 <a href="https://chat.deepseek.com/" target="_blank" class="tool-card modern-card">
                     <div class="tool-content">
                         <h3 class="text-xl font-bold mb-2 text-gray-800">Deepseek</h3>


### PR DESCRIPTION
## Summary
- add a ChatGPT card to the AI Foundation Models section on the homepage linking to chatgpt.com

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb2b4152948321a904272d2a533ce1