### PR TITLE
Add global language switcher

### DIFF
--- a/ai-ads.html
+++ b/ai-ads.html
@@ -758,5 +758,6 @@
             createParticles();
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/ai-capabilities.html
+++ b/ai-capabilities.html
@@ -829,5 +829,6 @@
             observer.observe(el);
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/ai-companies.html
+++ b/ai-companies.html
@@ -1021,5 +1021,6 @@
             createParticles();
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/ai-hotspots.html
+++ b/ai-hotspots.html
@@ -686,5 +686,6 @@
             createParticles();
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/ai-overseas.html
+++ b/ai-overseas.html
@@ -738,5 +738,6 @@
             createParticles();
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/ai-ranking.html
+++ b/ai-ranking.html
@@ -1850,5 +1850,6 @@
             createParticles();
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/ai-tools-landing.html
+++ b/ai-tools-landing.html
@@ -269,5 +269,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/aiagent.html
+++ b/aiagent.html
@@ -42,5 +42,6 @@
             </div>
         </section>
     </main>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/aicommunity.html
+++ b/aicommunity.html
@@ -450,5 +450,6 @@
             <p class="text-sm text-gray-500">© 2024 AI社群. 联系我们 wx zhangyouxun2013</p>
         </div>
     </footer>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/aicontent.html
+++ b/aicontent.html
@@ -42,5 +42,6 @@
             </div>
         </section>
     </main>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/ailearn.html
+++ b/ailearn.html
@@ -462,5 +462,6 @@
             }
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/ailinks.html
+++ b/ailinks.html
@@ -582,5 +582,6 @@
             <p class="text-sm text-gray-500">© 2024 AI工具导航. 联系我们 wx zhangyouxun2013</p>
         </div>
     </footer>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/ainum.html
+++ b/ainum.html
@@ -157,5 +157,6 @@
             <p class="text-sm text-gray-500">© 2024 AI数字人导航. 联系我们 wx zhangyouxun2013</p>
         </div>
     </footer>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/aioffice.html
+++ b/aioffice.html
@@ -462,5 +462,6 @@
             }
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/aiprompt.html
+++ b/aiprompt.html
@@ -462,5 +462,6 @@
             }
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/aitimer.html
+++ b/aitimer.html
@@ -513,5 +513,6 @@
             }
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/audio.html
+++ b/audio.html
@@ -751,5 +751,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/chuhai.html
+++ b/chuhai.html
@@ -824,5 +824,6 @@
             }
         }
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/coding.html
+++ b/coding.html
@@ -981,5 +981,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/debug-logo-issue.html
+++ b/debug-logo-issue.html
@@ -270,5 +270,6 @@
             }
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/debug-logo-simple.html
+++ b/debug-logo-simple.html
@@ -209,5 +209,6 @@
             updateStatus('loading', '准备就绪，点击按钮开始测试');
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/debug-logos.html
+++ b/debug-logos.html
@@ -284,5 +284,6 @@
             }, 2000);
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/designer.html
+++ b/designer.html
@@ -458,5 +458,6 @@
             observer.observe(el);
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/favicon-test.html
+++ b/favicon-test.html
@@ -299,5 +299,6 @@
             initTestGrid();
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/game.html
+++ b/game.html
@@ -999,5 +999,6 @@
             <p class="text-sm text-gray-500">© 2024 游戏导航. 联系我们 wx zhangyouxun2013</p>
         </div>
     </footer>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/gametest.html
+++ b/gametest.html
@@ -319,5 +319,6 @@
             <p class="text-sm text-gray-500">© 2024 游戏测试. 联系我们 wx zhangyouxun2013</p>
         </div>
     </footer>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/hanghai.html
+++ b/hanghai.html
@@ -496,5 +496,6 @@
             }
         }
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/image.html
+++ b/image.html
@@ -751,5 +751,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/img.html
+++ b/img.html
@@ -979,5 +979,6 @@
       setTimeout(handleViewportChange, 100);
     });
   </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/index-bilingual.html
+++ b/index-bilingual.html
@@ -816,5 +816,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/index-en.html
+++ b/index-en.html
@@ -599,5 +599,6 @@
             }
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/index.html
+++ b/index.html
@@ -1188,16 +1188,6 @@
             }
         }
         
-
-
-        // 语言切换
-        function switchLanguage(lang) {
-            const currentUrl = window.location.href;
-            const baseUrl = currentUrl.split('?')[0]; // 移除URL中的查询参数
-            const newUrl = `${baseUrl}?lang=${lang}`;
-            window.location.href = newUrl;
-        }
-        
         // 滚动动画
         const observerOptions = {
             threshold: 0.1,
@@ -1218,31 +1208,7 @@
             observer.observe(el);
         });
 
-        // 页面加载时检查URL参数并设置语言
         document.addEventListener('DOMContentLoaded', () => {
-            const urlParams = new URLSearchParams(window.location.search);
-            const lang = urlParams.get('lang');
-            if (lang === 'zh') {
-                // 切换到中文
-                document.getElementById('heroTitle').textContent = 'AI工具导航';
-                document.getElementById('heroSubtitle').textContent = '发现最佳AI工具，提升您的生产力';
-                document.querySelectorAll('.language-switch').forEach(button => {
-                    if (button.textContent === '中文') {
-                        button.style.background = 'var(--accent-color)';
-                        button.style.borderColor = 'var(--text-primary)';
-                    }
-                });
-            } else if (lang === 'en') {
-                // 切换到英文
-                document.getElementById('heroTitle').textContent = 'AI Tools Navigator';
-                document.getElementById('heroSubtitle').textContent = 'Discover the best AI tools to boost your productivity';
-                document.querySelectorAll('.language-switch').forEach(button => {
-                    if (button.textContent === 'English') {
-                        button.style.background = 'var(--accent-color)';
-                        button.style.borderColor = 'var(--text-primary)';
-                    }
-                });
-            }
             createParticles();
         });
     </script>
@@ -1271,5 +1237,6 @@
     <!-- 引入首页LOGO功能验证器 -->
     <script src="verify-homepage-logos.js"></script>
     
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/language-switcher.js
+++ b/language-switcher.js
@@ -1,0 +1,163 @@
+(function() {
+    const LANGUAGE_MAP = {
+        'zh-cn': 'zh-CN',
+        'zh': 'zh-CN',
+        'zh_hans': 'zh-CN',
+        'zh-hans': 'zh-CN',
+        'cn': 'zh-CN',
+        'en': 'en',
+        'en-us': 'en',
+        'english': 'en'
+    };
+
+    const normalizeLang = (value) => {
+        if (!value) return null;
+        const lower = value.toString().trim().toLowerCase();
+        if (!lower) return null;
+        if (LANGUAGE_MAP[lower]) return LANGUAGE_MAP[lower];
+        const base = lower.split('-')[0];
+        return LANGUAGE_MAP[base] || null;
+    };
+
+    const defaultLang = normalizeLang(document.documentElement.lang) || 'zh-CN';
+    let currentLang = defaultLang;
+    let translatorReady = false;
+    let pendingLang = null;
+
+    const setDocumentLang = (lang) => {
+        document.documentElement.setAttribute('lang', lang === 'zh-CN' ? 'zh-CN' : 'en');
+    };
+
+    const ensureTranslateContainer = () => {
+        if (!document.getElementById('google_translate_element')) {
+            const container = document.createElement('div');
+            container.id = 'google_translate_element';
+            container.style.display = 'none';
+            document.body.appendChild(container);
+        }
+    };
+
+    const createLanguageWidget = () => {
+        if (document.querySelector('.language-widget')) return;
+
+        const widget = document.createElement('div');
+        widget.className = 'language-widget shadow-lg';
+        widget.innerHTML = `
+            <button type="button" class="language-toggle-btn" data-lang="zh-CN" aria-label="切换到中文">中文</button>
+            <button type="button" class="language-toggle-btn" data-lang="en" aria-label="Switch to English">EN</button>
+        `;
+        document.body.appendChild(widget);
+    };
+
+    const updateActiveButtons = () => {
+        const normalizedCurrent = currentLang;
+        document.querySelectorAll('[data-lang]').forEach(element => {
+            const target = normalizeLang(element.getAttribute('data-lang'));
+            if (!target) return;
+            if (target === normalizedCurrent) {
+                element.classList.add('language-active');
+            } else {
+                element.classList.remove('language-active');
+            }
+        });
+    };
+
+    const applyLanguage = (lang) => {
+        const target = normalizeLang(lang) || defaultLang;
+        if (!translatorReady) {
+            pendingLang = target;
+            return;
+        }
+
+        const combo = document.querySelector('select.goog-te-combo');
+        if (!combo) {
+            setTimeout(() => applyLanguage(target), 120);
+            return;
+        }
+
+        if (combo.value !== target) {
+            combo.value = target;
+        }
+        combo.dispatchEvent(new Event('change'));
+    };
+
+    const setLanguage = (lang, options = {}) => {
+        const normalized = normalizeLang(lang) || defaultLang;
+        currentLang = normalized;
+        setDocumentLang(normalized);
+        updateActiveButtons();
+
+        if (!translatorReady) {
+            pendingLang = normalized;
+        } else {
+            applyLanguage(normalized);
+        }
+
+        if (!options.silent) {
+            localStorage.setItem('preferred-language', normalized);
+        }
+    };
+
+    const handleLanguageClick = (event) => {
+        const button = event.target.closest('[data-lang]');
+        if (!button) return;
+        event.preventDefault();
+        const targetLang = button.getAttribute('data-lang');
+        setLanguage(targetLang);
+    };
+
+    const loadGoogleTranslate = () => {
+        if (document.getElementById('google-translate-script')) return;
+        const script = document.createElement('script');
+        script.id = 'google-translate-script';
+        script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+        script.defer = true;
+        document.head.appendChild(script);
+    };
+
+    window.googleTranslateElementInit = function() {
+        const pageLang = defaultLang === 'zh-CN' ? 'zh-CN' : 'en';
+        new google.translate.TranslateElement({
+            pageLanguage: pageLang,
+            includedLanguages: 'en,zh-CN',
+            autoDisplay: false,
+            layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL
+        }, 'google_translate_element');
+
+        translatorReady = true;
+
+        if (pendingLang) {
+            const target = pendingLang;
+            pendingLang = null;
+            applyLanguage(target);
+        } else {
+            applyLanguage(currentLang);
+        }
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureTranslateContainer();
+        createLanguageWidget();
+        document.addEventListener('click', handleLanguageClick);
+        loadGoogleTranslate();
+
+        const stored = normalizeLang(localStorage.getItem('preferred-language'));
+        const initial = stored || defaultLang;
+        currentLang = initial;
+        setDocumentLang(initial);
+        updateActiveButtons();
+        setTimeout(updateActiveButtons, 300);
+
+        if (initial !== defaultLang) {
+            pendingLang = initial;
+        }
+
+        localStorage.setItem('preferred-language', initial);
+    });
+
+    window.LanguageSwitcher = {
+        setLanguage,
+        getCurrentLanguage: () => currentLang,
+        getDefaultLanguage: () => defaultLang
+    };
+})();

--- a/links.html
+++ b/links.html
@@ -282,5 +282,6 @@
             <p class="text-sm text-gray-500">© 2024 AI工具导航. 精选优质AI工具，联系我们 wx zhangyouxun2013</p>
         </div>
     </footer>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/logo-test.html
+++ b/logo-test.html
@@ -115,5 +115,6 @@
             }, 1000);
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/lunch-recommendations.html
+++ b/lunch-recommendations.html
@@ -511,5 +511,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/modern-styles.css
+++ b/modern-styles.css
@@ -552,3 +552,79 @@ body {
     0% { background-position: 200% 0; }
     100% { background-position: -200% 0; }
 }
+
+/* 全局语言切换器样式 */
+.language-widget {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 2000;
+    display: flex;
+    gap: 8px;
+    padding: 0.75rem;
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(16px);
+    border-radius: 9999px;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    box-shadow: var(--shadow-lg);
+}
+
+.language-toggle-btn {
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-weight: 600;
+    font-size: 0.875rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 9999px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.language-toggle-btn:hover {
+    color: var(--primary-color);
+    background: rgba(37, 99, 235, 0.08);
+}
+
+.language-toggle-btn.language-active,
+.language-switch.language-active {
+    background: var(--primary-color);
+    color: #fff;
+    box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.language-switch {
+    transition: all 0.2s ease;
+}
+
+/* Google 翻译元素隐藏处理 */
+#google_translate_element,
+.goog-te-banner-frame.skiptranslate,
+.goog-te-spinner-pos,
+.goog-te-gadget-icon {
+    display: none !important;
+}
+
+body {
+    top: 0 !important;
+}
+
+.goog-te-gadget {
+    height: 0 !important;
+    overflow: hidden !important;
+}
+
+@media (max-width: 640px) {
+    .language-widget {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+        bottom: 16px;
+        padding: 0.6rem 0.75rem;
+    }
+
+    .language-toggle-btn {
+        font-size: 0.8rem;
+        padding: 0.4rem 0.75rem;
+    }
+}

--- a/music.html
+++ b/music.html
@@ -376,5 +376,6 @@
 
     </div>
 
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/navigation.js
+++ b/navigation.js
@@ -176,8 +176,9 @@ class NavigationManager {
                 </nav>
 
                 <!-- 语言切换 -->
-                <div class="mt-8 pt-6 border-t border-gray-200">
-                    <button class="language-switch w-full" onclick="switchLanguage('en')">English</button>
+                <div class="mt-8 pt-6 border-t border-gray-200 space-y-2">
+                    <button class="language-switch w-full" data-lang="zh-CN">中文</button>
+                    <button class="language-switch w-full" data-lang="en">English</button>
                 </div>
             </div>
         `;
@@ -308,18 +309,24 @@ class NavigationManager {
             }
 
             .language-switch {
-                background: #2563EB;
+                background: rgba(37, 99, 235, 0.08);
                 border: none;
-                border-radius: 0.375rem;
+                border-radius: 0.5rem;
                 padding: 0.5rem 1rem;
-                color: white;
+                color: #2563EB;
                 font-weight: 500;
                 cursor: pointer;
                 transition: all 0.2s ease;
             }
 
             .language-switch:hover {
-                background: #1d4ed8;
+                background: rgba(37, 99, 235, 0.15);
+                color: #1d4ed8;
+            }
+
+            .language-switch.language-active {
+                background: #2563EB;
+                color: #ffffff;
             }
 
             /* 移动端响应式 */

--- a/play-game.html
+++ b/play-game.html
@@ -215,5 +215,6 @@
             </div>
         </div>
     </main>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/prayer.html
+++ b/prayer.html
@@ -430,5 +430,6 @@
             leaf.addEventListener('click', playLeafSound);
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/real-needs.html
+++ b/real-needs.html
@@ -779,5 +779,6 @@
             createParticles();
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/seo.html
+++ b/seo.html
@@ -454,5 +454,6 @@
             <p class="text-sm text-gray-500">© 2024 SEO工具导航. 联系我们 wx zhangyouxun2013</p>
         </div>
     </footer>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/simple-logo-test.html
+++ b/simple-logo-test.html
@@ -352,5 +352,6 @@
             initTestGrid();
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/sitemap.html
+++ b/sitemap.html
@@ -505,5 +505,6 @@
             }
         }
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/social.html
+++ b/social.html
@@ -786,5 +786,6 @@
             observer.observe(el);
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/test-ai-models-logos.html
+++ b/test-ai-models-logos.html
@@ -219,5 +219,6 @@
             }, 3000); // 等待3秒让LOGO加载完成
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/test-ai-ranking-layout.html
+++ b/test-ai-ranking-layout.html
@@ -97,5 +97,6 @@
             </ul>
         </div>
     </div>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/test-homepage-logos.html
+++ b/test-homepage-logos.html
@@ -182,5 +182,7 @@
             }, 2000);
         });
     </script>
+    <script src="language-switcher.js"></script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/test-page-introductions.html
+++ b/test-page-introductions.html
@@ -151,5 +151,6 @@
             }, 2000);
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/test-trends-update.html
+++ b/test-trends-update.html
@@ -244,5 +244,6 @@
             </div>
         </div>
     </div>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/trends.html
+++ b/trends.html
@@ -664,5 +664,6 @@
             observer.observe(el);
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html>

--- a/video.html
+++ b/video.html
@@ -751,5 +751,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/words.html
+++ b/words.html
@@ -574,5 +574,6 @@
             }
         }
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/writing.html
+++ b/writing.html
@@ -751,5 +751,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 

--- a/xiaohongshu.html
+++ b/xiaohongshu.html
@@ -687,5 +687,6 @@
             });
         });
     </script>
+    <script src="language-switcher.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
## Summary
- add a reusable `language-switcher.js` module that loads Google Translate, inserts a floating Chinese/English toggle, and remembers the user’s choice across pages
- extend the shared stylesheet with styles for the floating widget and hide default Google Translate UI elements for a cleaner presentation
- refresh the sidebar navigation language controls and attach the language switcher to every HTML page while removing the old URL based toggle logic on the home page

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccb538185083219fd1fdb170180ef8