### PR TITLE
Add Grok to homepage AI models section

### DIFF
--- a/homepage-logo-optimizer.js
+++ b/homepage-logo-optimizer.js
@@ -112,6 +112,7 @@ class HomepageLogoOptimizer {
             'perplexity.ai': '🤔',
             'chatbot.app': '💬',
             'claude.ai': '🧠',
+            'grok.com': '🤖',
             'cloudflare.com': '☁️',
             'vercel.com': '▲',
             'domain.com': '🌐',

--- a/homepage-logos.js
+++ b/homepage-logos.js
@@ -51,12 +51,15 @@ class HomepageLogoManager {
             'chatbot.app': 'https://chat.chatbot.app/favicon.ico',
             'chat.chatbot.app': 'https://chat.chatbot.app/favicon.ico',
             'claude.ai': 'https://claude.ai/favicon.ico',
+            'grok.com': 'https://grok.com/favicon.ico',
+            'www.grok.com': 'https://grok.com/favicon.ico',
             // 备用高质量LOGO
             'deepseek': 'https://chat.deepseek.com/favicon.ico',
             'gemini': 'https://www.google.com/favicon.ico',
             'perplexity': 'https://www.perplexity.ai/favicon.ico',
             'chatbot': 'https://chat.chatbot.app/favicon.ico',
             'claude': 'https://claude.ai/favicon.ico',
+            'grok': 'https://grok.com/favicon.ico',
             
             // Website Services
             'cloudflare.com': 'https://www.cloudflare.com/favicon.ico',
@@ -187,6 +190,7 @@ class HomepageLogoManager {
             'perplexity.ai': '🤔',
             'chatbot.app': '💬',
             'claude.ai': '🧠',
+            'grok.com': '🤖',
             'cloudflare.com': '☁️',
             'vercel.com': '▲',
             'domain.com': '🌐',

--- a/homepage-tool-logos.js
+++ b/homepage-tool-logos.js
@@ -63,6 +63,7 @@ class HomepageToolLogoManager {
         const perplexityLogoUrl = 'https://www.perplexity.ai/favicon.ico';
         const chatbotLogoUrl = 'https://chat.chatbot.app/favicon.ico';
         const claudeLogoUrl = 'https://claude.ai/favicon.ico';
+        const grokLogoUrl = 'https://grok.com/favicon.ico';
         const domainLogoUrl = 'https://www.domain.com/favicon.ico';
         const queryDomainsLogoUrl = 'https://query.domains/favicon.ico';
         const spaceshipLogoUrl = 'https://www.spaceship.com/favicon.ico';
@@ -84,6 +85,8 @@ class HomepageToolLogoManager {
             'chat.chatbot.app': createLogoConfig(chatbotLogoUrl, '💬', 'ChatBot'),
             'chatbot.app': createLogoConfig(chatbotLogoUrl, '💬', 'ChatBot'),
             'claude.ai': createLogoConfig(claudeLogoUrl, '🧠', 'Claude'),
+            'grok.com': createLogoConfig(grokLogoUrl, '🤖', 'Grok'),
+            'www.grok.com': createLogoConfig(grokLogoUrl, '🤖', 'Grok'),
 
             // 网站服务
             'cloudflare.com': createLogoConfig(cloudflareLogoUrl, '☁️', 'Cloudflare'),
@@ -312,6 +315,7 @@ class HomepageToolLogoManager {
             'chatbot': '💬',
             'chatgpt': '🤖',
             'claude': '🧠',
+            'grok': '🤖',
             'cloudflare': '☁️',
             'vercel': '⚡',
             'domain': '🌐',

--- a/index.html
+++ b/index.html
@@ -848,6 +848,12 @@
                         <p class="text-gray-600">AI-powered Search Engine</p>
                     </div>
                 </a>
+                <a href="https://grok.com/" target="_blank" class="tool-card modern-card">
+                    <div class="tool-content">
+                        <h3 class="text-xl font-bold mb-2 text-gray-800">Grok</h3>
+                        <p class="text-gray-600">xAI Conversational AI</p>
+                    </div>
+                </a>
                 <a href="https://chat.chatbot.app/" target="_blank" class="tool-card modern-card">
                     <div class="tool-content">
                         <h3 class="text-xl font-bold mb-2 text-gray-800">ChatBot</h3>

--- a/verify-ai-models-logos.js
+++ b/verify-ai-models-logos.js
@@ -22,6 +22,11 @@ class AIModelsLogoVerifier {
                 expectedDomain: 'www.perplexity.ai'
             },
             {
+                name: 'Grok',
+                url: 'https://grok.com/',
+                expectedDomain: 'grok.com'
+            },
+            {
                 name: 'ChatBot',
                 url: 'https://chat.chatbot.app/',
                 expectedDomain: 'chat.chatbot.app'


### PR DESCRIPTION
## Summary
- add Grok card and link to the AI Foundation Models section on the homepage
- update homepage logo tooling so Grok icons load correctly
- include Grok in the AI model logo verification script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cce62ede4c83219a58bc9852446806