### PR TITLE
Enhance AI tools pages for 2025 SEO keywords

### DIFF
--- a/image.html
+++ b/image.html
@@ -5,18 +5,18 @@
      crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Image Tools - Best AI Image Generators & Editors | AI Navigator</title>
-    <meta name="description" content="Discover the best AI image generation tools, photo editors, and image creation platforms. From DALL-E to Midjourney, find the perfect AI image solution.">
-    <meta name="keywords" content="AI image generator, AI art, image creation, photo editor, DALL-E, Midjourney, Stable Diffusion">
+    <title>Best AI Image Generator Tools | Free Online AI Art</title>
+    <meta name="description" content="Create stunning visuals with the best free AI image generator tools. Compare top AI art platforms for creativity, design, and productivity.">
+    <meta name="keywords" content="best AI image tools, free AI image generator, ai image generator tools, ai art platforms, ai design tools, ai tools for designers">
     <meta name="author" content="AI Navigator">
     <meta name="robots" content="index, follow">
-    <meta property="og:title" content="AI Image Tools - Best AI Image Generators & Editors">
-    <meta property="og:description" content="Discover the best AI image generation tools and photo editors">
+    <meta property="og:title" content="Best AI Image Generator Tools | Free Online AI Art">
+    <meta property="og:description" content="Compare the best free AI image generator tools and AI art platforms for design teams.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.aiaiy.com/image/">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="AI Image Tools - Best AI Image Generators & Editors">
-    <meta name="twitter:description" content="Discover the best AI image generation tools and photo editors">
+    <meta name="twitter:title" content="Best AI Image Generator Tools | Free Online AI Art">
+    <meta name="twitter:description" content="Create stunning visuals with leading free AI image generators and design assistants.">
     <meta name="twitter:url" content="https://www.aiaiy.com/image/">
     <link rel="canonical" href="https://www.aiaiy.com/image/">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -445,13 +445,16 @@
     <section class="hero-section py-16 mb-8">
         <div class="container mx-auto px-4 text-center">
             <h1 class="gradient-text text-5xl md:text-7xl font-bold mb-6 leading-tight">
-                AI Image Tools
+                Best Free AI Image Tools
             </h1>
-            <h2 class="text-2xl md:text-3xl text-gray-600 mb-6 font-medium">
-                Create Stunning Images with AI
+            <h2 class="text-2xl md:text-3xl text-gray-600 mb-4 font-medium">
+                Top AI Art Generators in 2025
             </h2>
+            <h3 class="text-xl md:text-2xl text-gray-700 mb-4 font-semibold">
+                AI Tools for Designers
+            </h3>
             <p class="text-xl md:text-2xl text-gray-700 mb-8 max-w-3xl mx-auto font-light">
-                Discover the best AI image generators, photo editors, and creative tools
+                Explore ai image generator tools for brands, design studios, and creative teams looking for rapid inspiration and polished visuals.
             </p>
             
             <!-- Search Box -->

--- a/index.html
+++ b/index.html
@@ -28,26 +28,26 @@
  
     <meta name="google-adsense-account" content="ca-pub-8794607118520437">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Tools Navigator - The most comprehensive AI tools directory | AIAIY.COM</title>
-    <meta name="description" content="AI Tools Navigator is a professional AI tools directory covering foundation models, image editing, video production, writing, music, design, and more to help you quickly find the best AI assistants and tools.">
-    <meta name="keywords" content="AI tools, AI directory, AI navigation, AI assistants, foundation models, image editing, video production, writing tools, music tools, designer tools">
+    <title>AI Tools Navigator | Best Free AI Tools for 2025</title>
+    <meta name="description" content="Discover the best AI tools in 2025. Explore free AI image generators, video creators, chatbots, and productivity platforms with our AI Tools Navigator.">
+    <meta name="keywords" content="AI tools, free AI tools, best AI tools, ai tools for business, ai tools for students, ai image generator tools, ai video generator online, ai text to speech tools, ai chatbot platform, compare ai tools 2025, free ai tools without login">
     <meta name="author" content="AI Tools Navigator">
     <meta name="robots" content="index, follow">
-    <meta property="og:title" content="AI Tools Navigator - Comprehensive AI tools directory">
-    <meta property="og:description" content="Discover the best AI tools across categories including foundation models, image, video, writing, music, and design.">
+    <meta property="og:title" content="AI Tools Navigator | Best Free AI Tools for 2025">
+    <meta property="og:description" content="Explore free AI tools, compare artificial intelligence platforms, and find top solutions for students, businesses, and creators.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.aiaiy.com/">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="AI Tools Navigator - Comprehensive AI tools directory">
-    <meta name="twitter:description" content="Discover the best AI tools across categories and boost your productivity.">
+    <meta name="twitter:title" content="AI Tools Navigator | Best Free AI Tools for 2025">
+    <meta name="twitter:description" content="Compare the best free AI tools for 2025, including image, video, chatbot, and productivity platforms.">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://www.aiaiy.com/">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "name": "AI工具导航",
-        "description": "AI工具导航是专业的人工智能工具导航网站，收录最全面的AI工具，包括大模型、AI图片处理、AI视频制作、AI文字处理、AI音乐、AI设计师工具等",
+        "name": "AI Tools Navigator 2025",
+        "description": "Discover free AI tools for students, businesses, and creators, including AI image generator tools, AI video generator online platforms, AI text to speech tools, and chatbot solutions.",
         "url": "https://www.aiaiy.com/",
         "potentialAction": {
             "@type": "SearchAction",
@@ -805,26 +805,84 @@
         <!-- 页面标题区域 -->
         <div class="bg-gradient-to-r from-blue-600 to-purple-600 text-white py-16 mb-8">
             <div class="max-w-7xl mx-auto px-4 text-center">
-                <h1 class="text-5xl font-bold mb-4">AI Tools Navigator</h1>
-                <p class="text-xl opacity-90 max-w-3xl mx-auto">Discover the best AI tools to boost your productivity</p>
+                <h1 class="text-5xl font-bold mb-4">AI Tools Navigator 2025</h1>
+                <p class="text-xl opacity-90 max-w-3xl mx-auto">Compare the best free AI tools without login for developers, students, creators, and businesses.</p>
                 <div class="mt-8 flex justify-center space-x-4">
                     <div class="bg-white bg-opacity-20 rounded-full px-6 py-2 text-sm">
-                        🚀 Latest AI Tools
+                        🚀 Free AI Tools Online
                     </div>
                     <div class="bg-white bg-opacity-20 rounded-full px-6 py-2 text-sm">
-                        💡 Smart Recommendations
+                        💡 AI API Integration
                     </div>
                     <div class="bg-white bg-opacity-20 rounded-full px-6 py-2 text-sm">
-                        🔍 Precise Search
+                        ⚙️ Productivity Automation
                     </div>
                 </div>
             </div>
         </div>
 
         <!-- 🤖 大模型 板块置顶 -->
+        <section class="max-w-7xl mx-auto px-4 py-12" aria-labelledby="free-ai-tools-online">
+            <h2 id="free-ai-tools-online" class="text-3xl font-bold text-center text-gray-900 mb-6">Free AI Tools Online</h2>
+            <p class="text-lg text-gray-600 max-w-4xl mx-auto text-center mb-10">Explore curated free AI tools online, from open source AI tools to platforms that work without login. Our navigator highlights ai image generator tools, ai video generator online suites, ai text to speech tools, and ai chatbot platforms built for rapid AI API integration.</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                <a href="image.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
+                    <div class="text-sm uppercase tracking-wide text-blue-500 font-semibold mb-2">Creative</div>
+                    <div class="text-xl font-bold text-gray-900 mb-2">AI Image Generator Tools</div>
+                    <p class="text-gray-600 text-sm">Generate artwork, mockups, and branded visuals with free AI tools and open source models.</p>
+                </a>
+                <a href="video.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
+                    <div class="text-sm uppercase tracking-wide text-purple-500 font-semibold mb-2">Marketing</div>
+                    <div class="text-xl font-bold text-gray-900 mb-2">AI Video Generator Online</div>
+                    <p class="text-gray-600 text-sm">Create promos and tutorials in minutes with browser-based AI video makers and automated editors.</p>
+                </a>
+                <a href="audio.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
+                    <div class="text-sm uppercase tracking-wide text-emerald-500 font-semibold mb-2">Voice</div>
+                    <div class="text-xl font-bold text-gray-900 mb-2">AI Text to Speech Tools</div>
+                    <p class="text-gray-600 text-sm">Convert scripts into realistic narration, podcasts, and tutorials with multilingual voices.</p>
+                </a>
+                <a href="aiagent.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
+                    <div class="text-sm uppercase tracking-wide text-amber-500 font-semibold mb-2">Support</div>
+                    <div class="text-xl font-bold text-gray-900 mb-2">AI Chatbot Platform</div>
+                    <p class="text-gray-600 text-sm">Deploy conversational assistants that blend chat automation with powerful machine learning tools.</p>
+                </a>
+            </div>
+        </section>
+
+        <section class="bg-slate-50 py-14" aria-labelledby="compare-best-ai-tools">
+            <div class="max-w-7xl mx-auto px-4">
+                <h2 id="compare-best-ai-tools" class="text-3xl font-bold text-center text-gray-900 mb-6">Compare the Best AI Tools</h2>
+                <p class="text-lg text-gray-600 max-w-4xl mx-auto text-center">Use our AI Tools Navigator to compare ai tools 2025 across every artificial intelligence platform category. Track machine learning tools for research, evaluate productivity automation stacks, and follow trending AI startups before they go mainstream.</p>
+                <div class="mt-12 grid grid-cols-1 md:grid-cols-2 gap-10">
+                    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-8">
+                        <h3 class="text-2xl font-semibold text-gray-900 mb-4">AI Tools for Students</h3>
+                        <p class="text-gray-600 mb-4">Empower learners with course-ready copilots, note-taking assistants, and creative studios that emphasize free ai tools without login barriers.</p>
+                        <ul class="space-y-2 text-gray-600">
+                            <li class="flex items-start gap-2"><span class="text-blue-500 mt-1">•</span><span>Collaborative writing suites, flashcard generators, and AI text to speech tools for accessibility.</span></li>
+                            <li class="flex items-start gap-2"><span class="text-blue-500 mt-1">•</span><span>Open source AI tools that help with coding practice, research summaries, and visual project ideas.</span></li>
+                        </ul>
+                    </div>
+                    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-8">
+                        <h3 class="text-2xl font-semibold text-gray-900 mb-4">AI Tools for Business</h3>
+                        <p class="text-gray-600 mb-4">Streamline customer journeys with AI chatbot platforms, marketing copilots, and dashboards that connect through AI API integration.</p>
+                        <ul class="space-y-2 text-gray-600">
+                            <li class="flex items-start gap-2"><span class="text-purple-500 mt-1">•</span><span>Productivity automation workflows for sales, support, and content production.</span></li>
+                            <li class="flex items-start gap-2"><span class="text-purple-500 mt-1">•</span><span>Artificial intelligence platforms that surface insights on trending AI startups and competitor moves.</span></li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
+                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Compare AI Tools 2025 Guide</span>
+                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Artificial Intelligence Platform Reviews</span>
+                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Machine Learning Tools Catalog</span>
+                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Trending AI Startups Radar</span>
+                </div>
+            </div>
+        </section>
+
         <div class="max-w-7xl mx-auto px-4 py-12" id="ai-models">
         <section class="mb-20 fade-in">
-            <h2 class="category-title">AI Foundation Models</h2>
+            <h2 class="category-title">AI Foundation Models &amp; Machine Learning Tools</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6">
                 <a href="https://chatgpt.com/" target="_blank" class="tool-card modern-card">
                     <div class="tool-content">

--- a/video.html
+++ b/video.html
@@ -5,18 +5,18 @@
      crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Video Tools - Best AI Video Generators & Editors | AI Navigator</title>
-    <meta name="description" content="Discover the best AI video generation tools, video editors, and content creation platforms. From HeyGen to Runway, find the perfect AI video solution.">
-    <meta name="keywords" content="AI video generator, video creation, video editor, HeyGen, Runway, Pika Labs, video AI">
+    <title>AI Video Generator Tools | Free Online AI Video Maker</title>
+    <meta name="description" content="Explore AI video generator tools for content creators. Create videos online with free AI-powered platforms for marketing and social media.">
+    <meta name="keywords" content="AI video generator tools, free AI video tools, ai video generator online, ai video maker, ai video tools for marketing, ai video tools comparison">
     <meta name="author" content="AI Navigator">
     <meta name="robots" content="index, follow">
-    <meta property="og:title" content="AI Video Tools - Best AI Video Generators & Editors">
-    <meta property="og:description" content="Discover the best AI video generation tools and video editors">
+    <meta property="og:title" content="AI Video Generator Tools | Free Online AI Video Maker">
+    <meta property="og:description" content="Create videos online with free AI-powered platforms for marketing and social media teams.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.aiaiy.com/video/">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="AI Video Tools - Best AI Video Generators & Editors">
-    <meta name="twitter:description" content="Discover the best AI video generation tools and video editors">
+    <meta name="twitter:title" content="AI Video Generator Tools | Free Online AI Video Maker">
+    <meta name="twitter:description" content="Explore AI video generators, editors, and marketing tools for fast video production.">
     <meta name="twitter:url" content="https://www.aiaiy.com/video/">
     <link rel="canonical" href="https://www.aiaiy.com/video/">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -445,13 +445,16 @@
     <section class="hero-section py-16 mb-8">
         <div class="container mx-auto px-4 text-center">
             <h1 class="gradient-text text-5xl md:text-7xl font-bold mb-6 leading-tight">
-                AI Video Tools
+                AI Video Generator Platforms
             </h1>
-            <h2 class="text-2xl md:text-3xl text-gray-600 mb-6 font-medium">
-                Create Amazing Videos with AI
+            <h2 class="text-2xl md:text-3xl text-gray-600 mb-4 font-medium">
+                Free AI Video Tools for Marketing
             </h2>
+            <h3 class="text-xl md:text-2xl text-gray-700 mb-4 font-semibold">
+                AI Video Tools Comparison
+            </h3>
             <p class="text-xl md:text-2xl text-gray-700 mb-8 max-w-3xl mx-auto font-light">
-                Discover the best AI video generators, editors, and content creation tools
+                Review ai video generator online suites, automated editors, and collaborative storytellers tailored to social media and brand campaigns.
             </p>
             
             <!-- Search Box -->


### PR DESCRIPTION
## Summary
- update the homepage metadata, hero copy, and schema to target 2025 free AI tool keywords
- add new homepage sections highlighting free AI tool categories and comparison guidance for students and businesses
- refresh the AI image and video category pages with updated metadata and headings that match the SEO plan

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d2b2d013c08321932404ba83f08328