### PR TITLE
Fix canonical URLs for standalone pages

### DIFF
--- a/audio.html
+++ b/audio.html
@@ -13,12 +13,12 @@
     <meta property="og:title" content="AI Audio Tools - Best AI Audio Generators & Editors">
     <meta property="og:description" content="Discover the best AI audio generation tools and music creators">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.aiaiy.com/audio/">
+    <meta property="og:url" content="https://www.aiaiy.com/audio.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Audio Tools - Best AI Audio Generators & Editors">
     <meta name="twitter:description" content="Discover the best AI audio generation tools and music creators">
-    <meta name="twitter:url" content="https://www.aiaiy.com/audio/">
-    <link rel="canonical" href="https://www.aiaiy.com/audio/">
+    <meta name="twitter:url" content="https://www.aiaiy.com/audio.html">
+    <link rel="canonical" href="https://www.aiaiy.com/audio.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>

--- a/coding.html
+++ b/coding.html
@@ -13,12 +13,12 @@
     <meta property="og:title" content="AI Coding Tools - Best AI Code Assistants & Development Tools">
     <meta property="og:description" content="Discover the best AI coding tools and development assistants">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.aiaiy.com/coding/">
+    <meta property="og:url" content="https://www.aiaiy.com/coding.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Coding Tools - Best AI Code Assistants & Development Tools">
     <meta name="twitter:description" content="Discover the best AI coding tools and development assistants">
-    <meta name="twitter:url" content="https://www.aiaiy.com/coding/">
-    <link rel="canonical" href="https://www.aiaiy.com/coding/">
+    <meta name="twitter:url" content="https://www.aiaiy.com/coding.html">
+    <link rel="canonical" href="https://www.aiaiy.com/coding.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>

--- a/fix_canonical_trailing_slash.py
+++ b/fix_canonical_trailing_slash.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Fix canonical and social URL tags pointing to trailing-slash paths."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+def main() -> None:
+    root = Path(__file__).parent
+    html_files = sorted(root.glob('*.html'))
+
+    # Regex matching URLs like https://www.aiaiy.com/page/
+    url_pattern = re.compile(r'https://www\.aiaiy\.com/([a-z0-9-]+)/')
+
+    updated_files = 0
+    total_replacements = 0
+
+    for html_path in html_files:
+        original = html_path.read_text(encoding='utf-8')
+        modified = original
+
+        def replace(match: re.Match[str]) -> str:
+            nonlocal total_replacements
+            slug = match.group(1)
+            candidate = root / f'{slug}.html'
+            if candidate.exists():
+                total_replacements += 1
+                return f'https://www.aiaiy.com/{slug}.html'
+            return match.group(0)
+
+        modified = url_pattern.sub(replace, modified)
+
+        if modified != original:
+            html_path.write_text(modified, encoding='utf-8')
+            updated_files += 1
+            print(f'Updated canonical URLs in {html_path.name}')
+
+    print(f"Processed {len(html_files)} HTML files.")
+    print(f"Updated {updated_files} files with {total_replacements} replacements.")
+
+if __name__ == '__main__':
+    main()

--- a/image.html
+++ b/image.html
@@ -13,12 +13,12 @@
     <meta property="og:title" content="Best AI Image Generator Tools | Free Online AI Art">
     <meta property="og:description" content="Compare the best free AI image generator tools and AI art platforms for design teams.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.aiaiy.com/image/">
+    <meta property="og:url" content="https://www.aiaiy.com/image.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Best AI Image Generator Tools | Free Online AI Art">
     <meta name="twitter:description" content="Create stunning visuals with leading free AI image generators and design assistants.">
-    <meta name="twitter:url" content="https://www.aiaiy.com/image/">
-    <link rel="canonical" href="https://www.aiaiy.com/image/">
+    <meta name="twitter:url" content="https://www.aiaiy.com/image.html">
+    <link rel="canonical" href="https://www.aiaiy.com/image.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>

--- a/seo.html
+++ b/seo.html
@@ -6,12 +6,12 @@
     <title>SEO工具导航 - 搜索引擎优化工具集合 | AIAIY.COM</title>
     <meta name="description" content="专业的SEO工具导航，收录主流搜索引擎优化工具，包括关键词分析、网站诊断、排名监控等工具，助力网站SEO优化">
     <meta name="keywords" content="SEO工具,搜索引擎优化,关键词分析,网站诊断,排名监控,SEO导航">
-    <meta property="og:url" content="https://www.aiaiy.com/seo/">
+    <meta property="og:url" content="https://www.aiaiy.com/seo.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="SEO工具导航 - 搜索引擎优化工具集合">
     <meta name="twitter:description" content="专业的SEO工具导航，收录主流搜索引擎优化工具，包括关键词分析、网站诊断、排名监控等工具，助力网站SEO优化">
-    <meta name="twitter:url" content="https://www.aiaiy.com/seo/">
-    <link rel="canonical" href="https://www.aiaiy.com/seo/">
+    <meta name="twitter:url" content="https://www.aiaiy.com/seo.html">
+    <link rel="canonical" href="https://www.aiaiy.com/seo.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         :root {

--- a/social.html
+++ b/social.html
@@ -11,19 +11,19 @@
     <meta property="og:title" content="社交媒体 - AI工具导航">
     <meta property="og:description" content="AI工具导航社交媒体页面，收录最热门的社交媒体平台">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.aiaiy.com/social/">
+    <meta property="og:url" content="https://www.aiaiy.com/social.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="社交媒体 - AI工具导航">
     <meta name="twitter:description" content="AI工具导航社交媒体页面，收录最热门的社交媒体平台">
-    <meta name="twitter:url" content="https://www.aiaiy.com/social/">
-    <link rel="canonical" href="https://www.aiaiy.com/social/">
+    <meta name="twitter:url" content="https://www.aiaiy.com/social.html">
+    <link rel="canonical" href="https://www.aiaiy.com/social.html">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
         "name": "社交媒体",
         "description": "AI工具导航社交媒体页面，收录最热门的社交媒体平台",
-        "url": "https://www.aiaiy.com/social/"
+        "url": "https://www.aiaiy.com/social.html"
     }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/video.html
+++ b/video.html
@@ -13,12 +13,12 @@
     <meta property="og:title" content="AI Video Generator Tools | Free Online AI Video Maker">
     <meta property="og:description" content="Create videos online with free AI-powered platforms for marketing and social media teams.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.aiaiy.com/video/">
+    <meta property="og:url" content="https://www.aiaiy.com/video.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Video Generator Tools | Free Online AI Video Maker">
     <meta name="twitter:description" content="Explore AI video generators, editors, and marketing tools for fast video production.">
-    <meta name="twitter:url" content="https://www.aiaiy.com/video/">
-    <link rel="canonical" href="https://www.aiaiy.com/video/">
+    <meta name="twitter:url" content="https://www.aiaiy.com/video.html">
+    <link rel="canonical" href="https://www.aiaiy.com/video.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>

--- a/writing.html
+++ b/writing.html
@@ -13,12 +13,12 @@
     <meta property="og:title" content="AI Writing Tools - Best AI Writing Assistants & Content Creators">
     <meta property="og:description" content="Discover the best AI writing tools and content creators for your writing needs">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.aiaiy.com/writing/">
+    <meta property="og:url" content="https://www.aiaiy.com/writing.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Writing Tools - Best AI Writing Assistants & Content Creators">
     <meta name="twitter:description" content="Discover the best AI writing tools and content creators">
-    <meta name="twitter:url" content="https://www.aiaiy.com/writing/">
-    <link rel="canonical" href="https://www.aiaiy.com/writing/">
+    <meta name="twitter:url" content="https://www.aiaiy.com/writing.html">
+    <link rel="canonical" href="https://www.aiaiy.com/writing.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>

--- a/xiaohongshu.html
+++ b/xiaohongshu.html
@@ -11,19 +11,19 @@
     <meta property="og:title" content="小红书工具 - AI工具导航">
     <meta property="og:description" content="AI工具导航小红书页面，收录最实用的小红书内容创作辅助工具">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.aiaiy.com/xiaohongshu/">
+    <meta property="og:url" content="https://www.aiaiy.com/xiaohongshu.html">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="小红书工具 - AI工具导航">
     <meta name="twitter:description" content="AI工具导航小红书页面，收录最实用的小红书内容创作辅助工具">
-    <meta name="twitter:url" content="https://www.aiaiy.com/xiaohongshu/">
-    <link rel="canonical" href="https://www.aiaiy.com/xiaohongshu/">
+    <meta name="twitter:url" content="https://www.aiaiy.com/xiaohongshu.html">
+    <link rel="canonical" href="https://www.aiaiy.com/xiaohongshu.html">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
         "name": "小红书工具",
         "description": "AI工具导航小红书页面，收录最实用的小红书内容创作辅助工具",
-        "url": "https://www.aiaiy.com/xiaohongshu/"
+        "url": "https://www.aiaiy.com/xiaohongshu.html"
     }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
## Summary
- update canonical, Open Graph, and Twitter URL tags on several standalone landing pages to point to their .html versions
- add a utility script to convert trailing-slash canonical URLs to their .html equivalents when the matching file exists

## Testing
- no automated tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d5f68cf7448321954d35758ff47865