### PR TITLE
Add trending AI keyword section to ai-capabilities page

### DIFF
--- a/ai-capabilities.html
+++ b/ai-capabilities.html
@@ -743,6 +743,112 @@
                     </a>
                 </div>
             </section>
+
+            <!-- 热门AI关键词 -->
+            <section class="mb-20 fade-in">
+                <h2 class="category-title">热门AI关键词趋势</h2>
+                <p class="category-subtitle">跟进高增长的AI话题，直达官方资源并快速了解它们能带来的价值</p>
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                    <a href="https://editprotips.com/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">ai work editprotips</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+150%</span>
+                        </div>
+                        <p class="tool-description">EditProTips围绕内容创作效率分享AI工作流，帮助视频与图像编辑者用AI提升修图、调色与自动化剪辑的速度。</p>
+                    </a>
+                    <a href="https://ainewstoday.com/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">ai news today</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+130%</span>
+                        </div>
+                        <p class="tool-description">AI News Today聚合每日人工智能要闻，覆盖行业发布、资本动态与政策解读，适合想要第一时间掌握趋势的从业者。</p>
+                    </a>
+                    <a href="https://www.heygen.com/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">heygen ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+110%</span>
+                        </div>
+                        <p class="tool-description">HeyGen提供虚拟人视频生成、声音克隆与多语言口播功能，让品牌快速产出专业级营销与培训视频。</p>
+                    </a>
+                    <a href="https://gemini.google.com/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">gemini ai สร้าง รูป</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+90%</span>
+                        </div>
+                        <p class="tool-description">Google Gemini支持多语言图像生成与创意写作，泰语用户可直接输入提示词生成高质量的视觉素材。</p>
+                    </a>
+                    <a href="https://www.turnitin.com/products/features/ai-detection" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">turnitin ai checker</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+90%</span>
+                        </div>
+                        <p class="tool-description">Turnitin AI Checker帮助教育机构检测作业中可能的AI生成内容，结合查重与AI特征分析确保学术诚信。</p>
+                    </a>
+                    <a href="https://www.meta.com/smart-glasses/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">meta ai glasses</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+70%</span>
+                        </div>
+                        <p class="tool-description">Meta AI智能眼镜整合视觉识别、实时翻译与语音助手，适合移动办公、旅行记录和创作者日常拍摄。</p>
+                    </a>
+                    <a href="https://www.pippit.ai/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">pippit ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+70%</span>
+                        </div>
+                        <p class="tool-description">Pippit AI聚焦客服自动化与多渠道消息响应，为中小企业提供无需代码的智能助理部署方案。</p>
+                    </a>
+                    <a href="https://www.notion.so/product/ai" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">notion ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+60%</span>
+                        </div>
+                        <p class="tool-description">Notion AI在文档、知识库和项目管理中提供写作、总结与翻译功能，是团队协作与个人效率的常备助手。</p>
+                    </a>
+                    <a href="https://www.agnes.ai/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">agnes ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+50%</span>
+                        </div>
+                        <p class="tool-description">Agnes AI面向销售团队构建自动化线索跟进与邮件助理，结合CRM数据实现更精准的客户洞察。</p>
+                    </a>
+                    <a href="https://www.perplexity.ai/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">perplexity ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+50%</span>
+                        </div>
+                        <p class="tool-description">Perplexity提供实时联网的问答搜索体验，以引用来源的形式输出摘要，非常适合进行快速资料调研。</p>
+                    </a>
+                    <a href="https://about.meta.com/meta-ai/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">meta ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+50%</span>
+                        </div>
+                        <p class="tool-description">Meta AI集合生成式助手、图像工具与开放模型，覆盖消费级设备、WhatsApp聊天以及开发者平台。</p>
+                    </a>
+                    <a href="https://www.spicyai.com/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">spicy ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+50%</span>
+                        </div>
+                        <p class="tool-description">Spicy AI为创作者提供脚本生成、短视频文案与社交媒体标题优化，让内容策划流程更轻松。</p>
+                    </a>
+                    <a href="https://lumalabs.ai/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">luma ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+40%</span>
+                        </div>
+                        <p class="tool-description">Luma AI通过NeRF与视频生成技术将手机拍摄的素材转换为3D场景，是设计师与影视工作室常用的建模助手。</p>
+                    </a>
+                    <a href="https://copilot.microsoft.com/" target="_blank" class="tool-card">
+                        <div class="flex items-start justify-between mb-2">
+                            <h3 class="mr-2">copilot ai</h3>
+                            <span class="text-xs font-semibold text-green-600 bg-green-100 px-2 py-1 rounded-full">+40%</span>
+                        </div>
+                        <p class="tool-description">Microsoft Copilot整合Office、Bing与Windows的AI助手功能，为知识工作者提供写作、分析与自动化支持。</p>
+                    </a>
+                </div>
+            </section>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- add a hot AI keywords section to ai-capabilities.html mirroring the homepage card style
- include growth badges, official links, and short descriptions for 14 trending AI search topics

## Testing
- not run (HTML content change)


------
https://chatgpt.com/codex/tasks/task_e_68d64b2f923c83219be70f9fea7881fc