### PR TITLE
Revamp AI foundation models showcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -884,50 +884,131 @@
 
         <div class="max-w-7xl mx-auto px-4 py-12" id="ai-models">
         <section class="mb-20 fade-in">
-            <h2 class="category-title">AI Foundation Models &amp; Machine Learning Tools</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6">
-                <a href="https://chatgpt.com/" target="_blank" class="tool-card modern-card">
-                    <div class="tool-content">
-                        <h3 class="text-xl font-bold mb-2 text-gray-800">ChatGPT</h3>
-                        <p class="text-gray-600">OpenAI Conversational AI</p>
+            <div class="ai-foundation-panel">
+                <div class="ai-foundation-header">
+                    <div>
+                        <span class="ai-foundation-kicker">Featured Foundation Models</span>
+                        <h2 class="category-title ai-foundation-title">AI Foundation Models &amp; Machine Learning Tools</h2>
+                        <p class="category-subtitle ai-foundation-subtitle">Explore multi-capability LLMs, copilots, and research copilots that power chat, search, and workflow automation.</p>
                     </div>
-                </a>
-                <a href="https://chat.deepseek.com/" target="_blank" class="tool-card modern-card">
-                    <div class="tool-content">
-                        <h3 class="text-xl font-bold mb-2 text-gray-800">Deepseek</h3>
-                        <p class="text-gray-600">Deep Learning Chat Model</p>
+                    <a href="ai-tools-landing.html" class="ai-foundation-link">
+                        View all AI tools
+                        <span aria-hidden="true">↗</span>
+                    </a>
+                </div>
+
+                <div class="ai-foundation-groups">
+                    <div class="ai-foundation-group">
+                        <div class="ai-foundation-group-header">
+                            <span class="ai-foundation-group-title">Conversational AI Studios</span>
+                            <span class="ai-foundation-group-subtitle">High-quality chat-first copilots</span>
+                        </div>
+                        <div class="ai-foundation-grid">
+                            <a href="https://chatgpt.com/" target="_blank" class="tool-card modern-card tool-card-compact">
+                                <div class="foundation-card-body">
+                                    <div class="foundation-card-top">
+                                        <span class="foundation-card-pill">Flagship model</span>
+                                        <span class="foundation-card-arrow" aria-hidden="true">↗</span>
+                                    </div>
+                                    <div class="foundation-card-text">
+                                        <h3 class="text-xl font-bold text-gray-800">ChatGPT</h3>
+                                        <p class="text-gray-600">OpenAI Conversational AI</p>
+                                    </div>
+                                </div>
+                            </a>
+                            <a href="https://claude.ai/" target="_blank" class="tool-card modern-card tool-card-compact">
+                                <div class="foundation-card-body">
+                                    <div class="foundation-card-top">
+                                        <span class="foundation-card-pill">Reasoning focus</span>
+                                        <span class="foundation-card-arrow" aria-hidden="true">↗</span>
+                                    </div>
+                                    <div class="foundation-card-text">
+                                        <h3 class="text-xl font-bold text-gray-800">Claude</h3>
+                                        <p class="text-gray-600">Anthropic AI Assistant</p>
+                                    </div>
+                                </div>
+                            </a>
+                            <a href="https://grok.com/" target="_blank" class="tool-card modern-card tool-card-compact">
+                                <div class="foundation-card-body">
+                                    <div class="foundation-card-top">
+                                        <span class="foundation-card-pill">Real-time data</span>
+                                        <span class="foundation-card-arrow" aria-hidden="true">↗</span>
+                                    </div>
+                                    <div class="foundation-card-text">
+                                        <h3 class="text-xl font-bold text-gray-800">Grok</h3>
+                                        <p class="text-gray-600">xAI Conversational AI</p>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
                     </div>
-                </a>
-                <a href="https://gemini.google.com/app" target="_blank" class="tool-card modern-card">
-                    <div class="tool-content">
-                        <h3 class="text-xl font-bold mb-2 text-gray-800">Google Gemini</h3>
-                        <p class="text-gray-600">Latest Google AI Assistant</p>
+
+                    <div class="ai-foundation-group">
+                        <div class="ai-foundation-group-header">
+                            <span class="ai-foundation-group-title">Multimodal Intelligence</span>
+                            <span class="ai-foundation-group-subtitle">Text, image, and reasoning models</span>
+                        </div>
+                        <div class="ai-foundation-grid">
+                            <a href="https://chat.deepseek.com/" target="_blank" class="tool-card modern-card tool-card-compact">
+                                <div class="foundation-card-body">
+                                    <div class="foundation-card-top">
+                                        <span class="foundation-card-pill">Research grade</span>
+                                        <span class="foundation-card-arrow" aria-hidden="true">↗</span>
+                                    </div>
+                                    <div class="foundation-card-text">
+                                        <h3 class="text-xl font-bold text-gray-800">Deepseek</h3>
+                                        <p class="text-gray-600">Deep Learning Chat Model</p>
+                                    </div>
+                                </div>
+                            </a>
+                            <a href="https://gemini.google.com/app" target="_blank" class="tool-card modern-card tool-card-compact">
+                                <div class="foundation-card-body">
+                                    <div class="foundation-card-top">
+                                        <span class="foundation-card-pill">Multimodal</span>
+                                        <span class="foundation-card-arrow" aria-hidden="true">↗</span>
+                                    </div>
+                                    <div class="foundation-card-text">
+                                        <h3 class="text-xl font-bold text-gray-800">Google Gemini</h3>
+                                        <p class="text-gray-600">Latest Google AI Assistant</p>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
                     </div>
-                </a>
-                <a href="https://www.perplexity.ai/" target="_blank" class="tool-card modern-card">
-                    <div class="tool-content">
-                        <h3 class="text-xl font-bold mb-2 text-gray-800">Perplexity</h3>
-                        <p class="text-gray-600">AI-powered Search Engine</p>
+
+                    <div class="ai-foundation-group">
+                        <div class="ai-foundation-group-header">
+                            <span class="ai-foundation-group-title">AI Agents &amp; Search</span>
+                            <span class="ai-foundation-group-subtitle">Find answers and build workflows</span>
+                        </div>
+                        <div class="ai-foundation-grid">
+                            <a href="https://www.perplexity.ai/" target="_blank" class="tool-card modern-card tool-card-compact">
+                                <div class="foundation-card-body">
+                                    <div class="foundation-card-top">
+                                        <span class="foundation-card-pill">Answer engine</span>
+                                        <span class="foundation-card-arrow" aria-hidden="true">↗</span>
+                                    </div>
+                                    <div class="foundation-card-text">
+                                        <h3 class="text-xl font-bold text-gray-800">Perplexity</h3>
+                                        <p class="text-gray-600">AI-powered Search Engine</p>
+                                    </div>
+                                </div>
+                            </a>
+                            <a href="https://chat.chatbot.app/" target="_blank" class="tool-card modern-card tool-card-compact">
+                                <div class="foundation-card-body">
+                                    <div class="foundation-card-top">
+                                        <span class="foundation-card-pill">Workflow ready</span>
+                                        <span class="foundation-card-arrow" aria-hidden="true">↗</span>
+                                    </div>
+                                    <div class="foundation-card-text">
+                                        <h3 class="text-xl font-bold text-gray-800">ChatBot</h3>
+                                        <p class="text-gray-600">AI Chat Assistant</p>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
                     </div>
-                </a>
-                <a href="https://grok.com/" target="_blank" class="tool-card modern-card">
-                    <div class="tool-content">
-                        <h3 class="text-xl font-bold mb-2 text-gray-800">Grok</h3>
-                        <p class="text-gray-600">xAI Conversational AI</p>
-                    </div>
-                </a>
-                <a href="https://chat.chatbot.app/" target="_blank" class="tool-card modern-card">
-                    <div class="tool-content">
-                        <h3 class="text-xl font-bold mb-2 text-gray-800">ChatBot</h3>
-                        <p class="text-gray-600">AI Chat Assistant</p>
-                    </div>
-                </a>
-                <a href="https://claude.ai/" target="_blank" class="tool-card modern-card">
-                    <div class="tool-content">
-                        <h3 class="text-xl font-bold mb-2 text-gray-800">Claude</h3>
-                        <p class="text-gray-600">Anthropic AI Assistant</p>
-                    </div>
-                </a>
+                </div>
             </div>
         </section>
 

--- a/modern-styles.css
+++ b/modern-styles.css
@@ -249,6 +249,218 @@ body {
     line-height: 1.5;
 }
 
+/* AI Foundation Models showcase */
+.ai-foundation-panel {
+    background: linear-gradient(140deg, #f1f5f9 0%, #ffffff 35%, #eff6ff 100%);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 28px;
+    padding: 2.5rem;
+    box-shadow: 0 25px 45px -20px rgba(15, 23, 42, 0.25);
+}
+
+@media (max-width: 640px) {
+    .ai-foundation-panel {
+        padding: 1.75rem;
+    }
+}
+
+.ai-foundation-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 2rem;
+}
+
+.ai-foundation-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #2563eb;
+    background: rgba(37, 99, 235, 0.08);
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    margin-bottom: 0.75rem;
+}
+
+.ai-foundation-title {
+    text-align: left;
+    margin-bottom: 0.75rem;
+}
+
+.ai-foundation-subtitle {
+    text-align: left;
+    margin-bottom: 0;
+    max-width: 38rem;
+    color: #475569;
+}
+
+.ai-foundation-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 1.25rem;
+    border-radius: 999px;
+    background: #1d4ed8;
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: none;
+    box-shadow: 0 15px 30px -12px rgba(37, 99, 235, 0.55);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ai-foundation-link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 35px -15px rgba(37, 99, 235, 0.6);
+}
+
+.ai-foundation-groups {
+    display: grid;
+    gap: 2.5rem;
+    margin-top: 2.5rem;
+}
+
+.ai-foundation-group {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.ai-foundation-group-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.ai-foundation-group-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    font-size: 1rem;
+    color: #1e293b;
+}
+
+.ai-foundation-group-title::before {
+    content: '';
+    width: 12px;
+    height: 12px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(14, 165, 233, 0.35));
+}
+
+.ai-foundation-group-subtitle {
+    font-size: 0.875rem;
+    color: #64748b;
+}
+
+.ai-foundation-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.tool-card-compact {
+    padding: 1.75rem 1.75rem 1.75rem 5.5rem;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 18px 35px -25px rgba(15, 23, 42, 0.6);
+}
+
+.tool-card-compact .tool-content {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    min-height: 120px;
+}
+
+.tool-card-compact > .tool-logo-bg {
+    position: absolute;
+    top: 1.6rem;
+    left: 1.75rem;
+    width: 56px;
+    height: 56px;
+    border-radius: 18px;
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.16), rgba(14, 165, 233, 0.16));
+    box-shadow: 0 12px 22px -12px rgba(15, 23, 42, 0.45);
+}
+
+.tool-card-compact > .tool-logo-bg .tool-logo-bg {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    opacity: 0.95;
+}
+
+.tool-card-compact .foundation-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.tool-card-compact .foundation-card-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.tool-card-compact .foundation-card-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: #0f172a;
+    background: rgba(226, 232, 240, 0.8);
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+}
+
+.tool-card-compact .foundation-card-arrow {
+    font-size: 1.3rem;
+    color: #1d4ed8;
+    transition: transform 0.2s ease;
+}
+
+.tool-card-compact:hover .foundation-card-arrow {
+    transform: translate(3px, -3px);
+}
+
+.tool-card-compact .foundation-card-text h3 {
+    font-size: 1.125rem;
+    margin-bottom: 0.35rem;
+}
+
+.tool-card-compact .foundation-card-text p {
+    color: #64748b;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+    .tool-card-compact {
+        padding: 1.5rem 1.5rem 1.5rem 4.75rem;
+    }
+
+    .tool-card-compact > .tool-logo-bg {
+        left: 1.5rem;
+        top: 1.35rem;
+    }
+}
+
 /* Clean category titles */
 .category-title {
     font-size: 2rem;


### PR DESCRIPTION
## Summary
- redesign the homepage "AI Foundation Models & Machine Learning Tools" section with grouped subcategories and CTA mirroring the referenced layout
- add compact card styling, panel framing, and responsive refinements in modern-styles.css to support the new foundation models showcase

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df156afe6c8321a12afbec8f895608