### PR TITLE
Move AI tools content near game overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -823,65 +823,6 @@
             </div>
         </div>
 
-        <!-- 🤖 大模型 板块置顶 -->
-        <section class="max-w-7xl mx-auto px-4 py-12" aria-labelledby="free-ai-tools-online">
-            <h2 id="free-ai-tools-online" class="text-3xl font-bold text-center text-gray-900 mb-6">Free AI Tools Online</h2>
-            <p class="text-lg text-gray-600 max-w-4xl mx-auto text-center mb-10">Explore curated free AI tools online, from open source AI tools to platforms that work without login. Our navigator highlights ai image generator tools, ai video generator online suites, ai text to speech tools, and ai chatbot platforms built for rapid AI API integration.</p>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                <a href="image.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
-                    <div class="text-sm uppercase tracking-wide text-blue-500 font-semibold mb-2">Creative</div>
-                    <div class="text-xl font-bold text-gray-900 mb-2">AI Image Generator Tools</div>
-                    <p class="text-gray-600 text-sm">Generate artwork, mockups, and branded visuals with free AI tools and open source models.</p>
-                </a>
-                <a href="video.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
-                    <div class="text-sm uppercase tracking-wide text-purple-500 font-semibold mb-2">Marketing</div>
-                    <div class="text-xl font-bold text-gray-900 mb-2">AI Video Generator Online</div>
-                    <p class="text-gray-600 text-sm">Create promos and tutorials in minutes with browser-based AI video makers and automated editors.</p>
-                </a>
-                <a href="audio.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
-                    <div class="text-sm uppercase tracking-wide text-emerald-500 font-semibold mb-2">Voice</div>
-                    <div class="text-xl font-bold text-gray-900 mb-2">AI Text to Speech Tools</div>
-                    <p class="text-gray-600 text-sm">Convert scripts into realistic narration, podcasts, and tutorials with multilingual voices.</p>
-                </a>
-                <a href="aiagent.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
-                    <div class="text-sm uppercase tracking-wide text-amber-500 font-semibold mb-2">Support</div>
-                    <div class="text-xl font-bold text-gray-900 mb-2">AI Chatbot Platform</div>
-                    <p class="text-gray-600 text-sm">Deploy conversational assistants that blend chat automation with powerful machine learning tools.</p>
-                </a>
-            </div>
-        </section>
-
-        <section class="bg-slate-50 py-14" aria-labelledby="compare-best-ai-tools">
-            <div class="max-w-7xl mx-auto px-4">
-                <h2 id="compare-best-ai-tools" class="text-3xl font-bold text-center text-gray-900 mb-6">Compare the Best AI Tools</h2>
-                <p class="text-lg text-gray-600 max-w-4xl mx-auto text-center">Use our AI Tools Navigator to compare ai tools 2025 across every artificial intelligence platform category. Track machine learning tools for research, evaluate productivity automation stacks, and follow trending AI startups before they go mainstream.</p>
-                <div class="mt-12 grid grid-cols-1 md:grid-cols-2 gap-10">
-                    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-8">
-                        <h3 class="text-2xl font-semibold text-gray-900 mb-4">AI Tools for Students</h3>
-                        <p class="text-gray-600 mb-4">Empower learners with course-ready copilots, note-taking assistants, and creative studios that emphasize free ai tools without login barriers.</p>
-                        <ul class="space-y-2 text-gray-600">
-                            <li class="flex items-start gap-2"><span class="text-blue-500 mt-1">•</span><span>Collaborative writing suites, flashcard generators, and AI text to speech tools for accessibility.</span></li>
-                            <li class="flex items-start gap-2"><span class="text-blue-500 mt-1">•</span><span>Open source AI tools that help with coding practice, research summaries, and visual project ideas.</span></li>
-                        </ul>
-                    </div>
-                    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-8">
-                        <h3 class="text-2xl font-semibold text-gray-900 mb-4">AI Tools for Business</h3>
-                        <p class="text-gray-600 mb-4">Streamline customer journeys with AI chatbot platforms, marketing copilots, and dashboards that connect through AI API integration.</p>
-                        <ul class="space-y-2 text-gray-600">
-                            <li class="flex items-start gap-2"><span class="text-purple-500 mt-1">•</span><span>Productivity automation workflows for sales, support, and content production.</span></li>
-                            <li class="flex items-start gap-2"><span class="text-purple-500 mt-1">•</span><span>Artificial intelligence platforms that surface insights on trending AI startups and competitor moves.</span></li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
-                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Compare AI Tools 2025 Guide</span>
-                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Artificial Intelligence Platform Reviews</span>
-                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Machine Learning Tools Catalog</span>
-                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Trending AI Startups Radar</span>
-                </div>
-            </div>
-        </section>
-
         <div class="max-w-7xl mx-auto px-4 py-12" id="ai-models">
         <section class="mb-20 fade-in">
             <h2 class="category-title">AI Foundation Models &amp; Machine Learning Tools</h2>
@@ -1129,6 +1070,65 @@
                         <h3 class="text-xl font-bold mb-2 text-gray-800">Cross-Platform</h3>
                         <p class="text-gray-600">Seamless experience across all devices and browsers</p>
                     </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 🤖 大模型 板块置顶 -->
+        <section class="max-w-7xl mx-auto px-4 py-12" aria-labelledby="free-ai-tools-online">
+            <h2 id="free-ai-tools-online" class="text-3xl font-bold text-center text-gray-900 mb-6">Free AI Tools Online</h2>
+            <p class="text-lg text-gray-600 max-w-4xl mx-auto text-center mb-10">Explore curated free AI tools online, from open source AI tools to platforms that work without login. Our navigator highlights ai image generator tools, ai video generator online suites, ai text to speech tools, and ai chatbot platforms built for rapid AI API integration.</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                <a href="image.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
+                    <div class="text-sm uppercase tracking-wide text-blue-500 font-semibold mb-2">Creative</div>
+                    <div class="text-xl font-bold text-gray-900 mb-2">AI Image Generator Tools</div>
+                    <p class="text-gray-600 text-sm">Generate artwork, mockups, and branded visuals with free AI tools and open source models.</p>
+                </a>
+                <a href="video.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
+                    <div class="text-sm uppercase tracking-wide text-purple-500 font-semibold mb-2">Marketing</div>
+                    <div class="text-xl font-bold text-gray-900 mb-2">AI Video Generator Online</div>
+                    <p class="text-gray-600 text-sm">Create promos and tutorials in minutes with browser-based AI video makers and automated editors.</p>
+                </a>
+                <a href="audio.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
+                    <div class="text-sm uppercase tracking-wide text-emerald-500 font-semibold mb-2">Voice</div>
+                    <div class="text-xl font-bold text-gray-900 mb-2">AI Text to Speech Tools</div>
+                    <p class="text-gray-600 text-sm">Convert scripts into realistic narration, podcasts, and tutorials with multilingual voices.</p>
+                </a>
+                <a href="aiagent.html" class="bg-white rounded-2xl shadow-md p-6 hover:shadow-xl transition-all border border-slate-100">
+                    <div class="text-sm uppercase tracking-wide text-amber-500 font-semibold mb-2">Support</div>
+                    <div class="text-xl font-bold text-gray-900 mb-2">AI Chatbot Platform</div>
+                    <p class="text-gray-600 text-sm">Deploy conversational assistants that blend chat automation with powerful machine learning tools.</p>
+                </a>
+            </div>
+        </section>
+
+        <section class="bg-slate-50 py-14" aria-labelledby="compare-best-ai-tools">
+            <div class="max-w-7xl mx-auto px-4">
+                <h2 id="compare-best-ai-tools" class="text-3xl font-bold text-center text-gray-900 mb-6">Compare the Best AI Tools</h2>
+                <p class="text-lg text-gray-600 max-w-4xl mx-auto text-center">Use our AI Tools Navigator to compare ai tools 2025 across every artificial intelligence platform category. Track machine learning tools for research, evaluate productivity automation stacks, and follow trending AI startups before they go mainstream.</p>
+                <div class="mt-12 grid grid-cols-1 md:grid-cols-2 gap-10">
+                    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-8">
+                        <h3 class="text-2xl font-semibold text-gray-900 mb-4">AI Tools for Students</h3>
+                        <p class="text-gray-600 mb-4">Empower learners with course-ready copilots, note-taking assistants, and creative studios that emphasize free ai tools without login barriers.</p>
+                        <ul class="space-y-2 text-gray-600">
+                            <li class="flex items-start gap-2"><span class="text-blue-500 mt-1">•</span><span>Collaborative writing suites, flashcard generators, and AI text to speech tools for accessibility.</span></li>
+                            <li class="flex items-start gap-2"><span class="text-blue-500 mt-1">•</span><span>Open source AI tools that help with coding practice, research summaries, and visual project ideas.</span></li>
+                        </ul>
+                    </div>
+                    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-8">
+                        <h3 class="text-2xl font-semibold text-gray-900 mb-4">AI Tools for Business</h3>
+                        <p class="text-gray-600 mb-4">Streamline customer journeys with AI chatbot platforms, marketing copilots, and dashboards that connect through AI API integration.</p>
+                        <ul class="space-y-2 text-gray-600">
+                            <li class="flex items-start gap-2"><span class="text-purple-500 mt-1">•</span><span>Productivity automation workflows for sales, support, and content production.</span></li>
+                            <li class="flex items-start gap-2"><span class="text-purple-500 mt-1">•</span><span>Artificial intelligence platforms that surface insights on trending AI startups and competitor moves.</span></li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
+                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Compare AI Tools 2025 Guide</span>
+                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Artificial Intelligence Platform Reviews</span>
+                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Machine Learning Tools Catalog</span>
+                    <span class="px-4 py-2 bg-white border border-slate-200 rounded-full text-sm font-medium text-gray-700">Trending AI Startups Radar</span>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- moved the Free AI Tools Online and Compare the Best AI Tools sections to sit directly above the About the Game block on the homepage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2feb9dcc83218f5b464ab85c473d