### PR TITLE
Remove Wood Block Jam intro paragraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -1139,7 +1139,6 @@
             <p class="category-subtitle">Learn more about Wood Block Jam and its developer</p>
             <div class="max-w-4xl mx-auto">
                 <div class="bg-white rounded-xl p-6 shadow-lg border border-gray-100">
-                    <p class="text-gray-700 leading-relaxed mb-4">Wood Block Jam is a puzzle game where every move matters. You're in for a treat if you love clever challenges wrapped in vibrant design. In this game, you must guide brightly-colored blocks through a crowded wooden grid to their matching exits.</p>
                     <p class="text-gray-700 leading-relaxed">Each block only moves in the direction it's pointing, so every move needs to be carefully thought out. Some paths are blocked while others are frozen. Some tiles twist around corners, while others won't budge until you make space.</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the introductory Wood Block Jam paragraph from the About the Game section on the homepage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df327193148321964c186f1bb20522