### PR TITLE
Add hotspot game link to homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,6 +919,7 @@
                     <a href="trends.html" class="nav-link-horizontal">📈 Trends</a>
                     <a href="ai-capabilities.html" class="nav-link-horizontal">⚡ AI Capabilities</a>
                     <a href="ai-money.html" class="nav-link-horizontal">💸 AI Money</a>
+                    <a href="https://hotspotgame.online/" class="nav-link-horizontal" target="_blank" rel="noopener noreferrer">🎮 热点游戏</a>
 
                     <div class="dropdown">
                         <button class="nav-link-horizontal dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">🛠️ Tools</button>
@@ -988,6 +989,7 @@
                     <a href="trends.html" class="mobile-nav-link">📈 Trends</a>
                     <a href="ai-capabilities.html" class="mobile-nav-link">⚡ AI Capabilities</a>
                     <a href="ai-money.html" class="mobile-nav-link">💸 AI Money</a>
+                    <a href="https://hotspotgame.online/" class="mobile-nav-link" target="_blank" rel="noopener noreferrer">🎮 热点游戏</a>
                     
                     <!-- 工具分组 -->
                     <div class="pt-3 mt-3 border-t border-slate-200/70">


### PR DESCRIPTION
## Summary
- add a Hotspot Game menu item to the desktop navigation
- mirror the Hotspot Game link in the mobile navigation drawer with a new tab target

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0c1d871f88321847e779b1000e146