### PR TITLE
Remove emojis from homepage navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -913,39 +913,39 @@
                 </div>
 
                 <nav class="nav-menu hidden lg:flex" aria-label="Primary navigation">
-                    <a href="index.html" class="nav-link-horizontal active">🏠 Home</a>
-                    <a href="ai-companies.html" class="nav-link-horizontal">🏢 AI Companies</a>
-                    <a href="ai-ranking.html" class="nav-link-horizontal">📊 AI Rankings</a>
-                    <a href="trends.html" class="nav-link-horizontal">📈 Trends</a>
-                    <a href="ai-capabilities.html" class="nav-link-horizontal">⚡ AI Capabilities</a>
-                    <a href="ai-money.html" class="nav-link-horizontal">💸 AI Money</a>
-                    <a href="https://hotspotgame.online/" class="nav-link-horizontal" target="_blank" rel="noopener noreferrer">🎮 热点游戏</a>
+                    <a href="index.html" class="nav-link-horizontal active">Home</a>
+                    <a href="ai-companies.html" class="nav-link-horizontal">AI Companies</a>
+                    <a href="ai-ranking.html" class="nav-link-horizontal">AI Rankings</a>
+                    <a href="trends.html" class="nav-link-horizontal">Trends</a>
+                    <a href="ai-capabilities.html" class="nav-link-horizontal">AI Capabilities</a>
+                    <a href="ai-money.html" class="nav-link-horizontal">AI Money</a>
+                    <a href="https://hotspotgame.online/" class="nav-link-horizontal" target="_blank" rel="noopener noreferrer">热点游戏</a>
 
                     <div class="dropdown">
-                        <button class="nav-link-horizontal dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">🛠️ Tools</button>
+                        <button class="nav-link-horizontal dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">Tools</button>
                         <div class="dropdown-menu">
                             <div class="dropdown-section">
                                 <div class="dropdown-section-title">Popular Tools</div>
-                                <a href="coding.html" class="dropdown-item">💻 Coding</a>
-                                <a href="designer.html" class="dropdown-item">🎨 Design</a>
-                                <a href="writing.html" class="dropdown-item">✍️ Writing</a>
-                                <a href="image.html" class="dropdown-item">🖼️ Image Editing</a>
-                                <a href="video.html" class="dropdown-item">🎬 Video</a>
-                                <a href="audio.html" class="dropdown-item">🎵 Audio</a>
+                                <a href="coding.html" class="dropdown-item">Coding</a>
+                                <a href="designer.html" class="dropdown-item">Design</a>
+                                <a href="writing.html" class="dropdown-item">Writing</a>
+                                <a href="image.html" class="dropdown-item">Image Editing</a>
+                                <a href="video.html" class="dropdown-item">Video</a>
+                                <a href="audio.html" class="dropdown-item">Audio</a>
                             </div>
                             <div class="dropdown-divider"></div>
                             <div class="dropdown-section">
                                 <div class="dropdown-section-title">AI Tools</div>
-                                <a href="ailinks.html" class="dropdown-item">🤖 AI Links</a>
-                                <a href="aicommunity.html" class="dropdown-item">👥 AI Community</a>
-                                <a href="aicontent.html" class="dropdown-item">📄 AI Content</a>
-                                <a href="ailearn.html" class="dropdown-item">📚 AI Learning</a>
-                                <a href="ainum.html" class="dropdown-item">🔢 AI Numbers</a>
-                                <a href="aioffice.html" class="dropdown-item">💼 AI Office</a>
-                                <a href="aiprompt.html" class="dropdown-item">💡 AI Prompts</a>
-                                <a href="aitimer.html" class="dropdown-item">⏰ AI Timer</a>
-                                <a href="aiagent.html" class="dropdown-item">🤖 AI Agents</a>
-                                <a href="batch-open.html" class="dropdown-item">🚀 Batch Launcher</a>
+                                <a href="ailinks.html" class="dropdown-item">AI Links</a>
+                                <a href="aicommunity.html" class="dropdown-item">AI Community</a>
+                                <a href="aicontent.html" class="dropdown-item">AI Content</a>
+                                <a href="ailearn.html" class="dropdown-item">AI Learning</a>
+                                <a href="ainum.html" class="dropdown-item">AI Numbers</a>
+                                <a href="aioffice.html" class="dropdown-item">AI Office</a>
+                                <a href="aiprompt.html" class="dropdown-item">AI Prompts</a>
+                                <a href="aitimer.html" class="dropdown-item">AI Timer</a>
+                                <a href="aiagent.html" class="dropdown-item">AI Agents</a>
+                                <a href="batch-open.html" class="dropdown-item">Batch Launcher</a>
                             </div>
                         </div>
                     </div>
@@ -983,38 +983,38 @@
                             <span class="favorite-button-label">收藏</span>
                         </button>
                     </div>
-                    <a href="index.html" class="mobile-nav-link active">🏠 Home</a>
-                    <a href="ai-companies.html" class="mobile-nav-link">🏢 AI Companies</a>
-                    <a href="ai-ranking.html" class="mobile-nav-link">📊 AI Rankings</a>
-                    <a href="trends.html" class="mobile-nav-link">📈 Trends</a>
-                    <a href="ai-capabilities.html" class="mobile-nav-link">⚡ AI Capabilities</a>
-                    <a href="ai-money.html" class="mobile-nav-link">💸 AI Money</a>
-                    <a href="https://hotspotgame.online/" class="mobile-nav-link" target="_blank" rel="noopener noreferrer">🎮 热点游戏</a>
+                    <a href="index.html" class="mobile-nav-link active">Home</a>
+                    <a href="ai-companies.html" class="mobile-nav-link">AI Companies</a>
+                    <a href="ai-ranking.html" class="mobile-nav-link">AI Rankings</a>
+                    <a href="trends.html" class="mobile-nav-link">Trends</a>
+                    <a href="ai-capabilities.html" class="mobile-nav-link">AI Capabilities</a>
+                    <a href="ai-money.html" class="mobile-nav-link">AI Money</a>
+                    <a href="https://hotspotgame.online/" class="mobile-nav-link" target="_blank" rel="noopener noreferrer">热点游戏</a>
                     
                     <!-- 工具分组 -->
                     <div class="pt-3 mt-3 border-t border-slate-200/70">
                         <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2 px-4">Popular Tools</div>
-                        <a href="coding.html" class="mobile-nav-link">💻 Coding</a>
-                        <a href="designer.html" class="mobile-nav-link">🎨 Design</a>
-                        <a href="writing.html" class="mobile-nav-link">✍️ Writing</a>
-                        <a href="image.html" class="mobile-nav-link">🖼️ Image Editing</a>
-                        <a href="video.html" class="mobile-nav-link">🎬 Video</a>
-                        <a href="audio.html" class="mobile-nav-link">🎵 Audio</a>
+                        <a href="coding.html" class="mobile-nav-link">Coding</a>
+                        <a href="designer.html" class="mobile-nav-link">Design</a>
+                        <a href="writing.html" class="mobile-nav-link">Writing</a>
+                        <a href="image.html" class="mobile-nav-link">Image Editing</a>
+                        <a href="video.html" class="mobile-nav-link">Video</a>
+                        <a href="audio.html" class="mobile-nav-link">Audio</a>
                     </div>
                     
                     <!-- AI工具分组 -->
                     <div class="pt-3 mt-3 border-t border-slate-200/70">
                         <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2 px-4">AI Tools</div>
-                        <a href="ailinks.html" class="mobile-nav-link">🤖 AI Links</a>
-                        <a href="aicommunity.html" class="mobile-nav-link">👥 AI Community</a>
-                        <a href="aicontent.html" class="mobile-nav-link">📄 AI Content</a>
-                        <a href="ailearn.html" class="mobile-nav-link">📚 AI Learning</a>
-                        <a href="ainum.html" class="mobile-nav-link">🔢 AI Numbers</a>
-                        <a href="aioffice.html" class="mobile-nav-link">💼 AI Office</a>
-                        <a href="aiprompt.html" class="mobile-nav-link">💡 AI Prompts</a>
-                        <a href="aitimer.html" class="mobile-nav-link">⏰ AI Timer</a>
-                        <a href="aiagent.html" class="mobile-nav-link">🤖 AI Agents</a>
-                        <a href="batch-open.html" class="mobile-nav-link">🚀 Batch Launcher</a>
+                        <a href="ailinks.html" class="mobile-nav-link">AI Links</a>
+                        <a href="aicommunity.html" class="mobile-nav-link">AI Community</a>
+                        <a href="aicontent.html" class="mobile-nav-link">AI Content</a>
+                        <a href="ailearn.html" class="mobile-nav-link">AI Learning</a>
+                        <a href="ainum.html" class="mobile-nav-link">AI Numbers</a>
+                        <a href="aioffice.html" class="mobile-nav-link">AI Office</a>
+                        <a href="aiprompt.html" class="mobile-nav-link">AI Prompts</a>
+                        <a href="aitimer.html" class="mobile-nav-link">AI Timer</a>
+                        <a href="aiagent.html" class="mobile-nav-link">AI Agents</a>
+                        <a href="batch-open.html" class="mobile-nav-link">Batch Launcher</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- remove decorative emojis from the homepage navigation links and dropdown entries
- keep desktop and mobile menus consistent with plain text labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a84799c883218405a5d3c7550412