### PR TITLE
Simplify homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,336 +93,62 @@
             -moz-osx-font-smoothing: grayscale;
         }
         
-        /* 顶部横向导航栏 */
-        .top-navbar {
+        /* 顶部导航 */
+        .simple-navbar {
             position: sticky;
             top: 0;
             z-index: 1000;
-            background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.95));
-            border-bottom: 1px solid rgba(226, 232, 240, 0.7);
-            backdrop-filter: blur(20px);
-            box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.45);
-            transition: background 0.3s ease, box-shadow 0.3s ease;
+            background: #ffffff;
+            border-bottom: 1px solid var(--border-color);
         }
 
-        .nav-container {
+        .simple-navbar__container {
             display: flex;
             align-items: center;
             justify-content: space-between;
-            gap: 1.75rem;
-            padding: 0.85rem 0;
+            gap: 1rem;
+            flex-wrap: wrap;
+            padding: 0.75rem 0;
         }
 
-        .nav-brand {
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
-
-        .nav-brand-info {
+        .simple-navbar__brand {
             display: flex;
             flex-direction: column;
-            gap: 0.125rem;
-        }
-
-        .nav-brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
             color: var(--text-primary);
+            font-size: 1.5rem;
+            font-weight: 700;
+            text-decoration: none;
+            line-height: 1.1;
         }
 
-        .nav-brand-tagline {
+        .simple-navbar__tagline {
             font-size: 0.75rem;
-            font-weight: 600;
-            letter-spacing: 0.12em;
-            text-transform: uppercase;
+            font-weight: 500;
             color: var(--text-muted);
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
         }
 
-        .nav-menu {
+        .simple-navbar__links {
             display: flex;
             align-items: center;
-            gap: 0.35rem;
-            padding: 0.35rem;
-            background: rgba(241, 245, 249, 0.92);
-            border-radius: 9999px;
-            border: 1px solid rgba(226, 232, 240, 0.7);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+            gap: 1rem;
+            flex-wrap: wrap;
+            margin-left: auto;
         }
 
-        .nav-link-horizontal {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.35rem;
+        .simple-navbar__link {
             color: var(--text-secondary);
             text-decoration: none;
-            font-weight: 600;
+            font-weight: 500;
             font-size: 0.95rem;
-            padding: 0.65rem 1.1rem;
-            border-radius: 9999px;
-            transition: all 0.2s ease;
-            position: relative;
+            padding: 0.35rem 0;
         }
 
-        .nav-link-horizontal:hover {
+        .simple-navbar__link:hover,
+        .simple-navbar__link--active {
             color: var(--text-primary);
-            background: rgba(255, 255, 255, 0.95);
-            box-shadow: var(--shadow-sm);
-        }
-
-        .nav-link-horizontal.active {
-            color: #ffffff;
-            background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
-            box-shadow: 0 12px 25px -16px rgba(37, 99, 235, 0.8);
-        }
-
-        /* 下拉菜单样式 */
-        .dropdown {
-            position: relative;
-        }
-
-        .dropdown-toggle {
-            background: none;
-            border: none;
-            cursor: pointer;
-            font: inherit;
-            color: inherit;
-            display: inline-flex;
-            align-items: center;
-            gap: 0.35rem;
-        }
-
-        .dropdown-toggle::after {
-            content: '';
-            width: 0.5rem;
-            height: 0.5rem;
-            border-right: 2px solid currentColor;
-            border-bottom: 2px solid currentColor;
-            transform: rotate(45deg);
-            transition: transform 0.2s ease;
-        }
-
-        .dropdown:hover .dropdown-toggle::after {
-            transform: rotate(225deg);
-        }
-
-        .dropdown-menu {
-            position: absolute;
-            top: calc(100% + 0.75rem);
-            left: 50%;
-            transform: translate(-50%, -10px);
-            background: #ffffff;
-            border: 1px solid rgba(226, 232, 240, 0.9);
-            border-radius: 1rem;
-            box-shadow: var(--shadow-lg);
-            min-width: 260px;
-            padding: 0.75rem;
-            opacity: 0;
-            visibility: hidden;
-            transition: all 0.3s ease;
-            z-index: 1001;
-        }
-
-        .dropdown:hover .dropdown-menu {
-            opacity: 1;
-            visibility: visible;
-            transform: translate(-50%, 0);
-        }
-
-        .dropdown-section {
-            padding: 0.5rem;
-            border-radius: 0.75rem;
-        }
-
-        .dropdown-section-title {
-            font-size: 0.75rem;
             font-weight: 600;
-            color: #94a3b8;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            padding: 0.25rem 0.75rem 0.5rem;
-        }
-
-        .dropdown-item {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 0.65rem 0.75rem;
-            color: #1f2937;
-            text-decoration: none;
-            border-radius: 0.75rem;
-            transition: all 0.2s ease;
-            margin: 0.125rem 0;
-        }
-
-        .dropdown-item:hover {
-            background: #eff6ff;
-            color: var(--primary-color);
-        }
-
-        .dropdown-divider {
-            height: 1px;
-            background: rgba(226, 232, 240, 0.8);
-            margin: 0.35rem 0;
-        }
-
-        .nav-actions {
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
-
-        .favorite-button,
-        .favorite-icon-button {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            gap: 0.5rem;
-            border: none;
-            border-radius: 9999px;
-            cursor: pointer;
-            font-weight: 600;
-            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
-            background: linear-gradient(135deg, #1d4ed8, #0ea5e9);
-            color: #ffffff;
-            box-shadow: 0 15px 30px -18px rgba(14, 165, 233, 0.6);
-            padding: 0.55rem 1.1rem;
-        }
-
-        .favorite-icon-button {
-            width: 2.5rem;
-            height: 2.5rem;
-            padding: 0;
-        }
-
-        .favorite-button:hover,
-        .favorite-icon-button:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 18px 30px -16px rgba(37, 99, 235, 0.55);
-        }
-
-        .favorite-button:focus-visible,
-        .favorite-icon-button:focus-visible,
-        .mobile-favorite:focus-visible {
-            outline: 2px solid rgba(14, 165, 233, 0.4);
-            outline-offset: 3px;
-        }
-
-        .favorite-button.is-active,
-        .favorite-icon-button.is-active,
-        .mobile-favorite.is-active {
-            background: linear-gradient(135deg, #0f172a, #1d4ed8);
-            box-shadow: 0 18px 32px -18px rgba(15, 23, 42, 0.65);
-        }
-
-        .favorite-icon {
-            width: 1.1rem;
-            height: 1.1rem;
-            transition: transform 0.2s ease;
-        }
-
-        .favorite-icon path {
-            fill: none;
-            stroke: currentColor;
-            transition: fill 0.2s ease, stroke 0.2s ease;
-        }
-
-        .favorite-button.is-active .favorite-icon path,
-        .favorite-icon-button.is-active .favorite-icon path,
-        .mobile-favorite.is-active .favorite-icon path {
-            fill: currentColor;
-        }
-
-        .favorite-button.is-active .favorite-icon,
-        .favorite-icon-button.is-active .favorite-icon,
-        .mobile-favorite.is-active .favorite-icon {
-            transform: scale(1.05);
-        }
-
-        .favorite-button-label {
-            font-size: 0.95rem;
-            letter-spacing: 0.02em;
-        }
-
-        /* 移动端菜单 */
-        .mobile-menu-toggle {
-            background: none;
-            border: none;
-            color: #4b5563;
-            cursor: pointer;
-            padding: 0.5rem;
-            border-radius: 0.75rem;
-            transition: all 0.2s ease;
-        }
-
-        .mobile-menu-toggle:hover {
-            background: rgba(226, 232, 240, 0.6);
-            color: var(--primary-color);
-        }
-
-        .mobile-nav-link {
-            display: block;
-            padding: 0.85rem 1.25rem;
-            color: #1f2937;
-            text-decoration: none;
-            border-radius: 0.75rem;
-            transition: all 0.2s ease;
-        }
-
-        .mobile-nav-link:hover {
-            background: rgba(226, 232, 240, 0.5);
-            color: var(--primary-color);
-        }
-
-        .mobile-nav-link.active {
-            background: rgba(37, 99, 235, 0.08);
-            color: var(--primary-color);
-            font-weight: 600;
-        }
-
-        .mobile-menu {
-            background: rgba(248, 250, 252, 0.98);
-            border-top: 1px solid rgba(226, 232, 240, 0.7);
-            border-bottom: 1px solid rgba(226, 232, 240, 0.7);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
-        }
-
-        .mobile-menu a {
-            color: inherit;
-            text-decoration: none;
-            transition: background-color 0.2s ease, color 0.2s ease;
-        }
-
-        .mobile-menu a:hover {
-            background: rgba(226, 232, 240, 0.5);
-        }
-
-        .mobile-favorite {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 0.5rem;
-            width: 100%;
-            margin-top: 0.75rem;
-            padding: 0.85rem 1rem;
-            border-radius: 0.85rem;
-            border: none;
-            background: linear-gradient(135deg, #1d4ed8, #0ea5e9);
-            color: #ffffff;
-            font-weight: 600;
-            letter-spacing: 0.02em;
-            box-shadow: 0 16px 30px -20px rgba(37, 99, 235, 0.6);
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-
-        .mobile-favorite:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 18px 32px -18px rgba(14, 165, 233, 0.6);
-        }
-
-        .mobile-favorite svg {
-            width: 1.1rem;
-            height: 1.1rem;
         }
 
         .sr-only {
@@ -886,137 +612,22 @@
     <div class="particles" id="particles"></div>
     
     <!-- 顶部横向导航栏 -->
-    <header class="top-navbar">
+    <header class="simple-navbar">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="nav-container">
-                <div class="nav-brand">
-                    <a href="index.html" class="flex items-center gap-3">
-                        <span class="block">
-                          <svg width="40" height="40" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <defs>
-                              <linearGradient id="ai-logo-gradient" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
-                                <stop stop-color="#00f2fe"/>
-                                <stop offset="1" stop-color="#764ba2"/>
-                              </linearGradient>
-                            </defs>
-                            <circle cx="24" cy="24" r="22" fill="url(#ai-logo-gradient)" stroke="#222" stroke-width="2"/>
-                            <rect x="14" y="14" width="20" height="20" rx="6" fill="#18181b" stroke="url(#ai-logo-gradient)" stroke-width="2"/>
-                            <path d="M20 30V18M28 30V18M20 24H28" stroke="#00f2fe" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
-                            <circle cx="24" cy="24" r="3.5" fill="#00f2fe" fill-opacity="0.7"/>
-                          </svg>
-                        </span>
-                        <div class="nav-brand-info">
-                            <span class="nav-brand-title">AIAIY</span>
-                            <span class="nav-brand-tagline">AI Tools Navigator</span>
-                        </div>
-                    </a>
-                </div>
-
-                <nav class="nav-menu hidden lg:flex" aria-label="Primary navigation">
-                    <a href="index.html" class="nav-link-horizontal active">Home</a>
-                    <a href="ai-companies.html" class="nav-link-horizontal">AI Companies</a>
-                    <a href="ai-ranking.html" class="nav-link-horizontal">AI Rankings</a>
-                    <a href="trends.html" class="nav-link-horizontal">Trends</a>
-                    <a href="ai-capabilities.html" class="nav-link-horizontal">AI Capabilities</a>
-                    <a href="ai-money.html" class="nav-link-horizontal">AI Money</a>
-                    <a href="https://hotspotgame.online/" class="nav-link-horizontal" target="_blank" rel="noopener noreferrer">热点游戏</a>
-
-                    <div class="dropdown">
-                        <button class="nav-link-horizontal dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">Tools</button>
-                        <div class="dropdown-menu">
-                            <div class="dropdown-section">
-                                <div class="dropdown-section-title">Popular Tools</div>
-                                <a href="coding.html" class="dropdown-item">Coding</a>
-                                <a href="designer.html" class="dropdown-item">Design</a>
-                                <a href="writing.html" class="dropdown-item">Writing</a>
-                                <a href="image.html" class="dropdown-item">Image Editing</a>
-                                <a href="video.html" class="dropdown-item">Video</a>
-                                <a href="audio.html" class="dropdown-item">Audio</a>
-                            </div>
-                            <div class="dropdown-divider"></div>
-                            <div class="dropdown-section">
-                                <div class="dropdown-section-title">AI Tools</div>
-                                <a href="ailinks.html" class="dropdown-item">AI Links</a>
-                                <a href="aicommunity.html" class="dropdown-item">AI Community</a>
-                                <a href="aicontent.html" class="dropdown-item">AI Content</a>
-                                <a href="ailearn.html" class="dropdown-item">AI Learning</a>
-                                <a href="ainum.html" class="dropdown-item">AI Numbers</a>
-                                <a href="aioffice.html" class="dropdown-item">AI Office</a>
-                                <a href="aiprompt.html" class="dropdown-item">AI Prompts</a>
-                                <a href="aitimer.html" class="dropdown-item">AI Timer</a>
-                                <a href="aiagent.html" class="dropdown-item">AI Agents</a>
-                                <a href="batch-open.html" class="dropdown-item">Batch Launcher</a>
-                            </div>
-                        </div>
-                    </div>
+            <div class="simple-navbar__container">
+                <a href="index.html" class="simple-navbar__brand">AIAIY
+                    <span class="simple-navbar__tagline">AI Tools Navigator</span>
+                </a>
+                <nav class="simple-navbar__links" aria-label="Primary navigation">
+                    <a href="index.html" class="simple-navbar__link">Home</a>
+                    <a href="ai-companies.html" class="simple-navbar__link">AI Companies</a>
+                    <a href="ai-ranking.html" class="simple-navbar__link">AI Rankings</a>
+                    <a href="trends.html" class="simple-navbar__link">Trends</a>
+                    <a href="ai-capabilities.html" class="simple-navbar__link">AI Capabilities</a>
+                    <a href="ai-money.html" class="simple-navbar__link">AI Money</a>
+                    <a href="ai-tools-landing.html" class="simple-navbar__link">AI Tools</a>
+                    <a href="https://hotspotgame.online/" class="simple-navbar__link" target="_blank" rel="noopener noreferrer">热点游戏</a>
                 </nav>
-
-                <div class="nav-actions">
-                    <button type="button" class="favorite-button hidden lg:inline-flex" id="favoriteButton" data-favorite-button aria-pressed="false" title="收藏">
-                        <svg class="favorite-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <path d="M6 4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18l-7-4-7 4z"/>
-                        </svg>
-                        <span class="favorite-button-label">收藏</span>
-                    </button>
-                    <button type="button" class="favorite-icon-button lg:hidden" id="favoriteButtonCompact" data-favorite-button aria-pressed="false" aria-label="收藏当前页面" title="收藏">
-                        <svg class="favorite-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <path d="M6 4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18l-7-4-7 4z"/>
-                        </svg>
-                        <span class="sr-only favorite-button-label">收藏</span>
-                    </button>
-                    <button class="mobile-menu-toggle lg:hidden" id="mobileMenuToggle" aria-label="打开主导航">
-                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-                        </svg>
-                    </button>
-                </div>
-            </div>
-
-            <!-- 移动端导航菜单 -->
-            <div class="mobile-menu lg:hidden hidden" id="mobileMenu">
-                <div class="py-4 space-y-2">
-                    <div class="px-4">
-                        <button type="button" class="mobile-favorite" id="favoriteButtonMobile" data-favorite-button aria-pressed="false">
-                            <svg class="favorite-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M6 4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18l-7-4-7 4z"/>
-                            </svg>
-                            <span class="favorite-button-label">收藏</span>
-                        </button>
-                    </div>
-                    <a href="index.html" class="mobile-nav-link active">Home</a>
-                    <a href="ai-companies.html" class="mobile-nav-link">AI Companies</a>
-                    <a href="ai-ranking.html" class="mobile-nav-link">AI Rankings</a>
-                    <a href="trends.html" class="mobile-nav-link">Trends</a>
-                    <a href="ai-capabilities.html" class="mobile-nav-link">AI Capabilities</a>
-                    <a href="ai-money.html" class="mobile-nav-link">AI Money</a>
-                    <a href="https://hotspotgame.online/" class="mobile-nav-link" target="_blank" rel="noopener noreferrer">热点游戏</a>
-                    
-                    <!-- 工具分组 -->
-                    <div class="pt-3 mt-3 border-t border-slate-200/70">
-                        <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2 px-4">Popular Tools</div>
-                        <a href="coding.html" class="mobile-nav-link">Coding</a>
-                        <a href="designer.html" class="mobile-nav-link">Design</a>
-                        <a href="writing.html" class="mobile-nav-link">Writing</a>
-                        <a href="image.html" class="mobile-nav-link">Image Editing</a>
-                        <a href="video.html" class="mobile-nav-link">Video</a>
-                        <a href="audio.html" class="mobile-nav-link">Audio</a>
-                    </div>
-                    
-                    <!-- AI工具分组 -->
-                    <div class="pt-3 mt-3 border-t border-slate-200/70">
-                        <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2 px-4">AI Tools</div>
-                        <a href="ailinks.html" class="mobile-nav-link">AI Links</a>
-                        <a href="aicommunity.html" class="mobile-nav-link">AI Community</a>
-                        <a href="aicontent.html" class="mobile-nav-link">AI Content</a>
-                        <a href="ailearn.html" class="mobile-nav-link">AI Learning</a>
-                        <a href="ainum.html" class="mobile-nav-link">AI Numbers</a>
-                        <a href="aioffice.html" class="mobile-nav-link">AI Office</a>
-                        <a href="aiprompt.html" class="mobile-nav-link">AI Prompts</a>
-                        <a href="aitimer.html" class="mobile-nav-link">AI Timer</a>
-                        <a href="aiagent.html" class="mobile-nav-link">AI Agents</a>
-                        <a href="batch-open.html" class="mobile-nav-link">Batch Launcher</a>
-                    </div>
-                </div>
             </div>
         </div>
     </header>
@@ -1445,78 +1056,52 @@
     <script src="page-introductions.js"></script>
     
     <script>
-        // 移动端菜单控制
-        document.addEventListener('DOMContentLoaded', function() {
-            const mobileMenuToggle = document.getElementById('mobileMenuToggle');
-            const mobileMenu = document.getElementById('mobileMenu');
-            
-            // 移动端菜单切换功能
-            if (mobileMenuToggle && mobileMenu) {
-                mobileMenuToggle.addEventListener('click', function() {
-                    mobileMenu.classList.toggle('hidden');
-                });
-                
-                // 点击菜单外部关闭菜单
-                document.addEventListener('click', function(event) {
-                    if (!mobileMenuToggle.contains(event.target) && !mobileMenu.contains(event.target)) {
-                        mobileMenu.classList.add('hidden');
-                    }
-                });
-            }
-            
-            // 设置当前页面的活动状态
+        document.addEventListener('DOMContentLoaded', () => {
             const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-            const navLinks = document.querySelectorAll('.nav-link-horizontal, .mobile-nav-link');
-            navLinks.forEach(link => {
-                if (link.getAttribute('href') === currentPage) {
-                    link.classList.add('active');
+            document.querySelectorAll('.simple-navbar__link').forEach(link => {
+                const href = link.getAttribute('href');
+                if (!href) return;
+                const linkPath = href.split('?')[0];
+                if (linkPath === currentPage) {
+                    link.classList.add('simple-navbar__link--active');
                 }
             });
 
-            const FAVORITE_STORAGE_KEY = 'aiaiy-home-favorite';
-            const favoriteButtons = Array.from(document.querySelectorAll('[data-favorite-button]'));
-
-            const updateFavoriteUI = (isFavorited) => {
-                favoriteButtons.forEach(button => {
-                    button.classList.toggle('is-active', isFavorited);
-                    button.setAttribute('aria-pressed', String(isFavorited));
-                    const label = button.querySelector('.favorite-button-label');
-                    const labelText = isFavorited ? '已收藏' : '收藏';
-                    if (label) {
-                        label.textContent = labelText;
-                    }
-                    if (button.hasAttribute('title')) {
-                        button.setAttribute('title', labelText);
-                    }
-                    if (button.hasAttribute('aria-label')) {
-                        button.setAttribute('aria-label', isFavorited ? '取消收藏当前页面' : '收藏当前页面');
+            const urlParams = new URLSearchParams(window.location.search);
+            const lang = urlParams.get('lang');
+            if (lang === 'zh') {
+                const heroTitle = document.getElementById('heroTitle');
+                const heroSubtitle = document.getElementById('heroSubtitle');
+                if (heroTitle) {
+                    heroTitle.textContent = 'AI工具导航';
+                }
+                if (heroSubtitle) {
+                    heroSubtitle.textContent = '发现最佳AI工具，提升您的生产力';
+                }
+                document.querySelectorAll('.language-switch').forEach(button => {
+                    if (button.textContent === '中文') {
+                        button.style.background = 'var(--accent-color)';
+                        button.style.borderColor = 'var(--text-primary)';
                     }
                 });
-            };
-
-            let isFavorited = false;
-            try {
-                isFavorited = localStorage.getItem(FAVORITE_STORAGE_KEY) === 'true';
-            } catch (error) {
-                console.warn('收藏状态无法持久化：', error);
-            }
-
-            if (favoriteButtons.length) {
-                updateFavoriteUI(isFavorited);
-
-                favoriteButtons.forEach(button => {
-                    button.addEventListener('click', event => {
-                        event.stopPropagation();
-                        isFavorited = !isFavorited;
-                        updateFavoriteUI(isFavorited);
-                        try {
-                            localStorage.setItem(FAVORITE_STORAGE_KEY, String(isFavorited));
-                        } catch (error) {
-                            console.warn('收藏状态保存失败：', error);
-                        }
-                    });
+            } else if (lang === 'en') {
+                const heroTitle = document.getElementById('heroTitle');
+                const heroSubtitle = document.getElementById('heroSubtitle');
+                if (heroTitle) {
+                    heroTitle.textContent = 'AI Tools Navigator';
+                }
+                if (heroSubtitle) {
+                    heroSubtitle.textContent = 'Discover the best AI tools to boost your productivity';
+                }
+                document.querySelectorAll('.language-switch').forEach(button => {
+                    if (button.textContent === 'English') {
+                        button.style.background = 'var(--accent-color)';
+                        button.style.borderColor = 'var(--text-primary)';
+                    }
                 });
             }
+
+            createParticles();
         });
 
         // 粒子效果
@@ -1536,14 +1121,6 @@
         
 
 
-        // 语言切换
-        function switchLanguage(lang) {
-            const currentUrl = window.location.href;
-            const baseUrl = currentUrl.split('?')[0]; // 移除URL中的查询参数
-            const newUrl = `${baseUrl}?lang=${lang}`;
-            window.location.href = newUrl;
-        }
-        
         // 滚动动画
         const observerOptions = {
             threshold: 0.1,
@@ -1562,34 +1139,6 @@
         document.querySelectorAll('.fade-in').forEach((el, index) => {
             el.style.setProperty('--stagger-index', index);
             observer.observe(el);
-        });
-
-        // 页面加载时检查URL参数并设置语言
-        document.addEventListener('DOMContentLoaded', () => {
-            const urlParams = new URLSearchParams(window.location.search);
-            const lang = urlParams.get('lang');
-            if (lang === 'zh') {
-                // 切换到中文
-                document.getElementById('heroTitle').textContent = 'AI工具导航';
-                document.getElementById('heroSubtitle').textContent = '发现最佳AI工具，提升您的生产力';
-                document.querySelectorAll('.language-switch').forEach(button => {
-                    if (button.textContent === '中文') {
-                        button.style.background = 'var(--accent-color)';
-                        button.style.borderColor = 'var(--text-primary)';
-                    }
-                });
-            } else if (lang === 'en') {
-                // 切换到英文
-                document.getElementById('heroTitle').textContent = 'AI Tools Navigator';
-                document.getElementById('heroSubtitle').textContent = 'Discover the best AI tools to boost your productivity';
-                document.querySelectorAll('.language-switch').forEach(button => {
-                    if (button.textContent === 'English') {
-                        button.style.background = 'var(--accent-color)';
-                        button.style.borderColor = 'var(--text-primary)';
-                    }
-                });
-            }
-            createParticles();
         });
     </script>
     


### PR DESCRIPTION
## Summary
- replace the homepage navigation bar with a lightweight sticky header using simple typography
- streamline navigation markup to a single row of essential links with a subtle active state
- remove unused dropdown, favorite, and mobile menu scripts in favor of straightforward link highlighting

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1b6c6eec4832182c4bb5486b3d1ab