### PR TITLE
feat: add Robotics Transformer X to 大模型 section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1240,7 +1240,7 @@
         <div class="homepage-shell">
             <nav class="homepage-toolbar" aria-label="首页分区">
                 <span class="homepage-toolbar__label">浏览分区</span>
-                <a href="#models-hub" class="homepage-toolbar__link"><span>🧠 大模型</span><span class="homepage-toolbar__count">6</span></a>
+                <a href="#models-hub" class="homepage-toolbar__link"><span>🧠 大模型</span><span class="homepage-toolbar__count">7</span></a>
                 <a href="#creative-suite" class="homepage-toolbar__link"><span>🎨 创作</span><span class="homepage-toolbar__count">8</span></a>
                 <a href="#company-stack" class="homepage-toolbar__link"><span>🏢 AI 软件</span><span class="homepage-toolbar__count">12</span></a>
             </nav>
@@ -1260,6 +1260,7 @@
                         <a class="ai-card" href="https://chat.deepseek.com/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://chat.deepseek.com/favicon.ico" alt="DeepSeek logo" loading="lazy"></span><span class="ai-card__name">DeepSeek</span><span class="ai-card__tagline">偏推理能力的中文对话模型。</span></a>
                         <a class="ai-card" href="https://www.doubao.com/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://www.doubao.com/favicon.ico" alt="Doubao logo" loading="lazy"></span><span class="ai-card__name">Doubao</span><span class="ai-card__tagline">字节系日常效率助手。</span></a>
                         <a class="ai-card" href="https://kimi.moonshot.cn/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://logo.clearbit.com/moonshot.cn" alt="Kimi logo" loading="lazy"></span><span class="ai-card__name">Kimi</span><span class="ai-card__tagline">长上下文中文研究助手。</span></a>
+                        <a class="ai-card" href="https://robotics-transformer-x.github.io/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://robotics-transformer-x.github.io/favicon.ico" alt="Robotics Transformer X logo" loading="lazy"></span><span class="ai-card__name">Robotics Transformer X</span><span class="ai-card__tagline">机器人通用策略与具身智能模型。</span></a>
                     </div>
                 </section>
 


### PR DESCRIPTION
### Motivation
- 将 Robotics Transformer X 收录到首页“大模型”板块，以展示机器人通用策略与具身智能相关资源并保持显示计数一致。

### Description
- 在 `index.html` 的 `#models-hub` 卡片网格中添加指向 `https://robotics-transformer-x.github.io/` 的卡片，并将顶部导航 `大模型` 计数从 `6` 更新为 `7`。

### Testing
- 使用 `rg` 验证新卡片和计数（初次 `rg` 因 shell 引号转义错误失败，随后用 `rg -n "robotics-transformer-x|homepage-toolbar__count\">7" index.html` 成功），并通过 `git diff -- index.html` 与 `git commit` 确认变更已提交。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da412358e48321bcfbf752b9a58736)