### PR TITLE
feat(homepage): add Volcengine to models section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1240,7 +1240,7 @@
         <div class="homepage-shell">
             <nav class="homepage-toolbar" aria-label="首页分区">
                 <span class="homepage-toolbar__label">浏览分区</span>
-                <a href="#models-hub" class="homepage-toolbar__link"><span>🧠 大模型</span><span class="homepage-toolbar__count">6</span></a>
+                <a href="#models-hub" class="homepage-toolbar__link"><span>🧠 大模型</span><span class="homepage-toolbar__count">7</span></a>
                 <a href="#creative-suite" class="homepage-toolbar__link"><span>🎨 创作</span><span class="homepage-toolbar__count">8</span></a>
                 <a href="#company-stack" class="homepage-toolbar__link"><span>🏢 AI 软件</span><span class="homepage-toolbar__count">12</span></a>
             </nav>
@@ -1259,6 +1259,7 @@
                         <a class="ai-card" href="https://gemini.google.com/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://www.gstatic.com/lamda/images/share-favicon-512x512.png" alt="Gemini logo" loading="lazy"></span><span class="ai-card__name">Gemini</span><span class="ai-card__tagline">Google 生态下的多模态助手。</span></a>
                         <a class="ai-card" href="https://chat.deepseek.com/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://chat.deepseek.com/favicon.ico" alt="DeepSeek logo" loading="lazy"></span><span class="ai-card__name">DeepSeek</span><span class="ai-card__tagline">偏推理能力的中文对话模型。</span></a>
                         <a class="ai-card" href="https://www.doubao.com/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://www.doubao.com/favicon.ico" alt="Doubao logo" loading="lazy"></span><span class="ai-card__name">Doubao</span><span class="ai-card__tagline">字节系日常效率助手。</span></a>
+                        <a class="ai-card" href="https://www.volcengine.com/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://www.volcengine.com/favicon.ico" alt="Volcengine logo" loading="lazy"></span><span class="ai-card__name">Volcengine</span><span class="ai-card__tagline">火山引擎企业级模型与云服务平台。</span></a>
                         <a class="ai-card" href="https://kimi.moonshot.cn/" target="_blank" rel="noopener noreferrer"><span class="ai-card__logo"><img src="https://logo.clearbit.com/moonshot.cn" alt="Kimi logo" loading="lazy"></span><span class="ai-card__name">Kimi</span><span class="ai-card__tagline">长上下文中文研究助手。</span></a>
                     </div>
                 </section>


### PR DESCRIPTION
### Motivation
- Add Volcengine to the homepage “大模型” list so the site surfaces Volcengine as an enterprise model and cloud offering.

### Description
- Inserted an `ai-card` entry for `https://www.volcengine.com/` into `index.html` under `#models-hub` and updated the `🧠 大模型` toolbar count from `6` to `7` to keep the count in sync.

### Testing
- Verified with a small Python regex check that `#models-hub` contains 7 cards and the toolbar count is `7` (passed), and an attempted `bs4`-based DOM parse failed due to missing `bs4` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da423a52ac83219e3eb8feb6204f1e)