### PR TITLE
feat: expand self-media platforms list with Xiaohongshu, Zhihu, Douban, Weibo and Kuaishou

### DIFF
--- a/self-media-tools.html
+++ b/self-media-tools.html
@@ -424,12 +424,17 @@
             <section class="section">
                 <div class="section__header">
                     <h2 class="section__title">自媒体平台</h2>
-                    <span class="section__count">7 项</span>
+                    <span class="section__count">12 项</span>
                 </div>
                 <ul class="link-grid">
                     <li><a class="tool-link" href="https://channels.weixin.qq.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">公众号</div><div class="tool-link__domain">channels.weixin.qq.com</div></a></li>
                     <li><a class="tool-link" href="https://channels.weixin.qq.com/platform" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">视频号</div><div class="tool-link__domain">channels.weixin.qq.com/platform</div></a></li>
                     <li><a class="tool-link" href="https://www.douyin.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">抖音</div><div class="tool-link__domain">douyin.com</div></a></li>
+                    <li><a class="tool-link" href="https://www.xiaohongshu.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">小红书</div><div class="tool-link__domain">xiaohongshu.com</div></a></li>
+                    <li><a class="tool-link" href="https://www.zhihu.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">知乎</div><div class="tool-link__domain">zhihu.com</div></a></li>
+                    <li><a class="tool-link" href="https://www.douban.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">豆瓣</div><div class="tool-link__domain">douban.com</div></a></li>
+                    <li><a class="tool-link" href="https://www.weibo.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">微博</div><div class="tool-link__domain">weibo.com</div></a></li>
+                    <li><a class="tool-link" href="https://www.kuaishou.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">快手</div><div class="tool-link__domain">kuaishou.com</div></a></li>
                     <li><a class="tool-link" href="https://www.toutiao.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">头条</div><div class="tool-link__domain">toutiao.com</div></a></li>
                     <li><a class="tool-link" href="https://www.bilibili.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">B站</div><div class="tool-link__domain">bilibili.com</div></a></li>
                     <li><a class="tool-link" href="https://x.com/home" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">X</div><div class="tool-link__domain">x.com/home</div></a></li>


### PR DESCRIPTION
### Motivation
- Keep the site’s “自媒体平台” section up-to-date with common domestic Chinese platforms used by creators and marketers.
- Ensure the page listing and the displayed item count remain consistent for visitors.

### Description
- Updated `self-media-tools.html` to increase the “自媒体平台” section item count from `7 项` to `12 项` and preserve existing entries.
- Added links and labels for `小红书 (xiaohongshu.com)`, `知乎 (zhihu.com)`, `豆瓣 (douban.com)`, `微博 (weibo.com)`, and `快手 (kuaishou.com)` in the `self-media-tools.html` link grid.
- No other files or business logic were modified; this is a content-only change to the HTML page.

### Testing
- Verified presence of new platform entries and updated count using `rg -n '自媒体平台|section__count|小红书|知乎|豆瓣|微博|快手' self-media-tools.html`, which returned the expected matches and updated count.
- Render region inspected with `nl -ba self-media-tools.html | sed -n '420,446p'` to confirm the inserted list items and ordering, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7b60fee083218ec972476b0a1a06)