### PR TITLE
feat(homepage): route homepage product cards to product detail pages

### DIFF
--- a/homepage-product-navigation.js
+++ b/homepage-product-navigation.js
@@ -17,20 +17,29 @@
         return element ? element.textContent.trim() : '';
     };
 
+    const normalizeSectionId = (section) => {
+        if (!section) return '';
+        if (section.id) return section.id;
+
+        const heading = section.querySelector('h2, h3');
+        const headingText = heading ? heading.textContent.trim() : '';
+        return slugify(headingText);
+    };
+
     const findSectionInfo = (anchor) => {
         const section = anchor.closest('section');
         if (!section) {
             return {
-                title: 'Home Picks',
-                id: 'overview'
+                title: '首页推荐',
+                id: 'home-picks'
             };
         }
 
         const heading = section.querySelector('h2, h3');
-        const title = heading ? heading.textContent.trim() : 'Home Picks';
+        const title = heading ? heading.textContent.trim() : '首页推荐';
         return {
             title,
-            id: section.id || slugify(title)
+            id: normalizeSectionId(section) || slugify(title)
         };
     };
 
@@ -38,9 +47,9 @@
         if (!(anchor instanceof HTMLAnchorElement)) return null;
 
         const sectionInfo = findSectionInfo(anchor);
-        const name = anchor.dataset.productName || extractText(anchor, '.modern-card__title, .tool-card__title, h3');
-        const description = anchor.dataset.productSummary || extractText(anchor, '.modern-card__description, p');
-        const category = anchor.dataset.productCategory || extractText(anchor, '.modern-card__badge');
+        const name = anchor.dataset.productName || extractText(anchor, '.ai-card__name, .modern-card__title, .tool-card__title, h3');
+        const description = anchor.dataset.productSummary || extractText(anchor, '.ai-card__tagline, .modern-card__description, p');
+        const category = anchor.dataset.productCategory || extractText(anchor, '.ai-card__meta-item strong, .modern-card__badge');
         const badge = extractText(anchor, '.modern-card__badge');
         const logoImg = anchor.dataset.productLogo || (anchor.querySelector('img') ? anchor.querySelector('img').src : '');
         const website = anchor.dataset.productUrl || anchor.getAttribute('href');
@@ -54,16 +63,22 @@
         const keyFeatures = [];
         if (description) keyFeatures.push(description);
         if (badge && (!description || !description.includes(badge))) {
-            keyFeatures.push(`Feature: ${badge}`);
+            keyFeatures.push(`产品标签：${badge}`);
         }
 
-        const idealUsers = sectionInfo.title ? [`Best for visitors exploring ${sectionInfo.title}`] : [];
-        const highlights = badge ? [`Highlight: ${badge}`] : [];
+        const idealUsers = sectionInfo.title ? [`适合关注「${sectionInfo.title}」方向的用户`] : [];
+        const highlights = [];
+        if (badge) {
+            highlights.push(`亮点：${badge}`);
+        }
+        if (description) {
+            highlights.push(`首页推荐语：${description}`);
+        }
 
         return {
             id,
             name: name || website,
-            category: category || sectionInfo.title || 'AI Tools',
+            category: category || sectionInfo.title || 'AI 工具',
             summary,
             tagline: anchor.dataset.productTagline || summary,
             website,
@@ -71,7 +86,7 @@
             logo: logoImg,
             keyFeatures,
             idealUsers,
-            pricing: ['See official site for pricing details'],
+            pricing: ['请前往官网查看最新价格与套餐信息'],
             highlights,
             integrations: [],
             relatedTools: [],
@@ -106,10 +121,12 @@
     const attachInterceptors = () => {
         const candidates = new Set();
         const selectors = [
+            'a.ai-card',
             'a.modern-card',
             'a.tool-card',
             '.tool-card a',
-            '.modern-card a'
+            '.modern-card a',
+            '.ai-card a'
         ];
 
         selectors.forEach((selector) => {


### PR DESCRIPTION
### Motivation
- 为首页每个产品卡片提供独立详情页入口，保证在展示产品介绍后用户可继续跳转到对应官网。 
- 需要支持现有的首页卡片结构（特别是 `.ai-card`）并从卡片中提取名称、简介、分类与 logo 等字段以在详情页填充内容。 

### Description
- 改进 `homepage-product-navigation.js`，新增 `normalizeSectionId` 用于生成或复用分区 id，并将默认分区标题改为中文 `首页推荐`。 
- 扩展拦截器选择器以包含 `a.ai-card` 与 `.ai-card a`，并增强 `buildProductPayload` 以从 `.ai-card__name`、`.ai-card__tagline`、`.ai-card__meta-item strong` 等节点读取数据。 
- 本地化落地页生成内容为中文（比如 `pricing`、`highlights`、`idealUsers`），保留原始外链并通过 sessionStorage 存储 `pendingProduct` 后重定向到 `products/product.html?id=...`。 

### Testing
- 已对脚本语法执行检查：`node --check homepage-product-navigation.js`，检查通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0921cb7e8832199fce1aaadf56362)