### PR TITLE
feat: add Tencent Matrix AI detection link to self-media tools

### DIFF
--- a/self-media-tools.html
+++ b/self-media-tools.html
@@ -179,7 +179,7 @@
             <section class="section">
                 <div class="section__header">
                     <h2 class="section__title">常用自媒体工具</h2>
-                    <span class="section__count">7 项</span>
+                    <span class="section__count">8 项</span>
                 </div>
                 <ul class="link-grid">
                     <li><a class="tool-link" href="https://changfengbox.top/wechat" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">长风盒子 · 微信工具</div><div class="tool-link__domain">changfengbox.top/wechat</div></a></li>
@@ -189,6 +189,7 @@
                     <li><a class="tool-link" href="https://vcn1a2y2j9mv.feishu.cn/wiki/KsQxwTyiOin2GxkghAVcrrcjnM2" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">飞书 Wiki · 资料库</div><div class="tool-link__domain">feishu.cn/wiki/KsQx...</div></a></li>
                     <li><a class="tool-link" href="https://aistudio.google.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">Google AI Studio</div><div class="tool-link__domain">aistudio.google.com</div></a></li>
                     <li><a class="tool-link" href="https://poe.com" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">Poe</div><div class="tool-link__domain">poe.com</div></a></li>
+                    <li><a class="tool-link" href="https://matrix.tencent.com/ai-detect/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">腾讯朱雀 AI 检测</div><div class="tool-link__domain">matrix.tencent.com/ai-detect</div></a></li>
                 </ul>
             </section>
 


### PR DESCRIPTION
### Motivation
- Add a convenient AI-detection resource to the self-media tools list so creators can quickly access Tencent Matrix's AI-detect service.

### Description
- Updated `self-media-tools.html` by adding an entry linking to `https://matrix.tencent.com/ai-detect/` labeled `腾讯朱雀 AI 检测` and incremented the section count from `7 项` to `8 项`.

### Testing
- Verified the change with `git diff -- self-media-tools.html` and `git status --short`, and committed the update; no build or runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1bb8a2fa08321a51f4149edf7fd6e)