### PR TITLE
Update 自媒体平台 list: add 5 links and adjust count

### DIFF
--- a/self-media-tools.html
+++ b/self-media-tools.html
@@ -425,7 +425,7 @@
             <section class="section">
                 <div class="section__header">
                     <h2 class="section__title">自媒体平台</h2>
-                    <span class="section__count">12 项</span>
+                    <span class="section__count">17 项</span>
                 </div>
                 <ul class="link-grid">
                     <li><a class="tool-link" href="https://channels.weixin.qq.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">公众号</div><div class="tool-link__domain">channels.weixin.qq.com</div></a></li>
@@ -438,6 +438,11 @@
                     <li><a class="tool-link" href="https://www.kuaishou.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">快手</div><div class="tool-link__domain">kuaishou.com</div></a></li>
                     <li><a class="tool-link" href="https://www.toutiao.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">头条</div><div class="tool-link__domain">toutiao.com</div></a></li>
                     <li><a class="tool-link" href="https://www.bilibili.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">B站</div><div class="tool-link__domain">bilibili.com</div></a></li>
+                    <li><a class="tool-link" href="https://ad.yiban.io/?utm" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">壹伴</div><div class="tool-link__domain">ad.yiban.io</div></a></li>
+                    <li><a class="tool-link" href="https://www.135editor.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">135编辑器</div><div class="tool-link__domain">135editor.com</div></a></li>
+                    <li><a class="tool-link" href="https://www.bitbrowser.cn/?signup=1" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">指纹浏览器</div><div class="tool-link__domain">bitbrowser.cn/?signup=1</div></a></li>
+                    <li><a class="tool-link" href="https://exmail.qq.com/login" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">腾讯企业邮箱</div><div class="tool-link__domain">exmail.qq.com/login</div></a></li>
+                    <li><a class="tool-link" href="https://forwardemail.net/zh" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">邮件服务</div><div class="tool-link__domain">forwardemail.net/zh</div></a></li>
                     <li><a class="tool-link" href="https://x.com/home" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">X</div><div class="tool-link__domain">x.com/home</div></a></li>
                     <li><a class="tool-link" href="https://www.reddit.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">Reddit</div><div class="tool-link__domain">reddit.com</div></a></li>
                 </ul>


### PR DESCRIPTION
### Motivation
- Expand the "自媒体平台" section to include additional useful tools and services for content creators and marketers.

### Description
- Updated the visible item count from `12` to `17` for the "自媒体平台" section. 
- Added five new link entries to `self-media-tools.html`: `壹伴 (ad.yiban.io)`, `135编辑器 (135editor.com)`, `指纹浏览器 (bitbrowser.cn)`, `腾讯企业邮箱 (exmail.qq.com)`, and `邮件服务 (forwardemail.net/zh)`.

### Testing
- Ran `htmlhint self-media-tools.html` to validate HTML and style issues, which passed. 
- Ran the static build with `npm run build` to ensure no build-time errors, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1be21d96c83219c1fd08e43c1d1a8)