### PR TITLE
feat: 新增“自媒体平台 · 新增程序”板块（7 项工具）

### DIFF
--- a/self-media-tools.html
+++ b/self-media-tools.html
@@ -422,6 +422,24 @@
                     <li><a class="tool-link" href="https://developer.apple.com/app-store/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">App Store / Google Play 开发者平台（应用分发）</div><div class="tool-link__domain">developer.apple.com / play.google.com/console</div></a></li>
                 </ul>
             </section>
+
+
+            <section class="section">
+                <div class="section__header">
+                    <h2 class="section__title">自媒体平台 · 新增程序</h2>
+                    <span class="section__count">7 项</span>
+                </div>
+                <ul class="link-grid">
+                    <li><a class="tool-link" href="https://www.hepankeji.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">1）视频号下载神器（河畔科技下载机器人）</div><div class="tool-link__domain">hepankeji.com（视频号可直接分享给机器人下载）</div></a></li>
+                    <li><a class="tool-link" href="https://tingwu.aliyun.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">2）飞书妙计 / 通义听悟提取文案</div><div class="tool-link__domain">tingwu.aliyun.com（通义听悟提取速度更快）</div></a></li>
+                    <li><a class="tool-link" href="https://gemini.google.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">3）Gemini 改文案、生成剧本与分镜</div><div class="tool-link__domain">gemini.google.com（需谷歌账号与基础网络环境）</div></a></li>
+                    <li><a class="tool-link" href="https://www.zopia.ai/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">4）Zopia 生成人物视图、场景图、道具图</div><div class="tool-link__domain">zopia.ai（积分不足可在闲鱼等平台补充）</div></a></li>
+                    <li><a class="tool-link" href="https://jimeng.jianying.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">5）即梦生成分镜视频</div><div class="tool-link__domain">jimeng.jianying.com（时间与费用投入相对更高）</div></a></li>
+                    <li><a class="tool-link" href="https://aic.oceanengine.com/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">6）即创生成数字人口播视频</div><div class="tool-link__domain">aic.oceanengine.com（降低视频制作成本）</div></a></li>
+                    <li><a class="tool-link" href="https://www.liuliangbao.cn/" target="_blank" rel="noopener noreferrer"><div class="tool-link__name">7）流速工具监测视频流速并辅助开播时机</div><div class="tool-link__domain">liuliangbao.cn（避免错误开播导致流速下滑）</div></a></li>
+                </ul>
+            </section>
+
             <section class="section">
                 <div class="section__header">
                     <h2 class="section__title">自媒体平台</h2>


### PR DESCRIPTION
### Motivation
- 按自媒体工作流补充常用工具集合，方便内容创作者快速找到下载、文案提取、改写/分镜、出图与生成类服务。 

### Description
- 在 `self-media-tools.html` 中新增一个名为 “自媒体平台 · 新增程序” 的区块并加入 7 条卡片链接。 
- 新增条目包括：1) 视频号下载神器（河畔科技下载机器人），2) 飞书妙计 / 通义听悟提取文案，3) Gemini 改文案与生成剧本/分镜，4) Zopia 生成人物/场景/道具图，5) 即梦生成分镜视频，6) 即创生成数字人口播视频，7) 流速工具用于流速监测与开播时机判断。 
- 保持现有页面的样式与结构，不修改脚本逻辑或全局样式。

### Testing
- 已使用 `rg -n "自媒体平台 · 新增程序|hepankeji|流速工具" self-media-tools.html` 验证新增标题与关键条目，命令执行成功。 
- 已使用 `nl -ba self-media-tools.html | sed -n '420,455p'` 确认新板块位于预期位置且包含 7 项链接，输出符合预期。 
- 此为静态 HTML 内容更新，不涉及单元测试或运行时逻辑，相关视觉/链接可通过浏览器手动验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ce689de48321ae0e2e73dff4a80b)